### PR TITLE
Fix broken import on Django 1.6

### DIFF
--- a/django_object_actions/utils.py
+++ b/django_object_actions/utils.py
@@ -1,4 +1,4 @@
-from django.conf.urls.defaults import patterns
+from django.conf.urls import patterns
 from django.contrib import messages
 from django.http import Http404, HttpResponse, HttpResponseRedirect
 from django.views.generic import View


### PR DESCRIPTION
django.conf.urls.defaults is no longer a valid module to import from in Django 1.6. Thanks in advance!
