### PR TITLE
Add possibility to use acction not just for object instance but also for ...

### DIFF
--- a/django_object_actions/templates/django_object_actions/change_list.html
+++ b/django_object_actions/templates/django_object_actions/change_list.html
@@ -1,0 +1,14 @@
+{% extends "admin/change_list.html" %}
+{% load i18n future %}
+<!-- Object-Tools -->
+{% block object-tools-items %}
+  {% for tool in modelactions %}
+    <li class="modelactions-item" data-tool-name="{{ tool.name }}">
+      <a href='tools/{{ tool.name }}/' title="{{ tool.short_description }}">
+      {{ tool.label|capfirst }}
+      </a>
+    </li>
+  {% endfor %}
+  {{ block.super }}
+{% endblock %}
+

--- a/django_object_actions/templates/mezzanine_object_actions/change_form.html
+++ b/django_object_actions/templates/mezzanine_object_actions/change_form.html
@@ -1,0 +1,17 @@
+{% extends "admin/change_form.html" %}
+{% load i18n future %}
+
+{% block object-tools %}
+{% if change %}
+{% if not is_popup %}
+    <ul class="object-tools">
+    {% for tool in objectactions %}
+    <li class="objectaction-item" data-tool-name="{{ tool.name }}"><a href='tools/{{ tool.name }}/' title="{{ tool.short_description }}">{{ tool.label|capfirst }}</a></li>
+    {% endfor %}
+    <li><a href="{% url "admin:form_entries" object_id %}">{% trans "View entries" %}</a></li>
+    <li><a href="history/" class="historylink">{% trans "History" %}</a></li>
+    {% if has_absolute_url %}<li><a href="../../../r/{{ content_type_id }}/{{ object_id }}/" class="viewsitelink">{% trans "View on site" %}</a></li>{% endif%}
+    </ul>
+{% endif %}
+{% endif %}
+{% endblock %}

--- a/django_object_actions/templates/mezzanine_object_actions/change_list.html
+++ b/django_object_actions/templates/mezzanine_object_actions/change_list.html
@@ -1,0 +1,14 @@
+{% extends "admin/change_list.html" %}
+{% load i18n future %}
+<!-- Object-Tools -->
+{% block object-tools-items %}
+  {% for tool in modelactions %}
+    <li class="objectaction-item" data-tool-name="{{ tool.name }}">
+      <a href='tools/{{ tool.name }}/' title="{{ tool.short_description }}">
+      {{ tool.label|capfirst }}
+      </a>
+    </li>
+  {% endfor %}
+  {{ block.super }}
+{% endblock %}
+

--- a/django_object_actions/utils.py
+++ b/django_object_actions/utils.py
@@ -1,6 +1,6 @@
 from functools import wraps
 
-from django.conf.urls import patterns
+from django.conf.urls import url
 from django.contrib import messages
 from django.db.models.query import QuerySet
 from django.http import Http404, HttpResponse, HttpResponseRedirect
@@ -10,50 +10,85 @@ from django.views.generic.detail import SingleObjectMixin
 
 class DjangoObjectActions(object):
     """ModelAdmin mixin to add object-tools just like adding admin actions."""
+
+    # override default change_list_template
+    change_list_template = "django_object_actions/change_list.html"
     # override default change_form_template
     change_form_template = "django_object_actions/change_form.html"
     # list to hold each object action tool
     objectactions = []
+    # list to hold each model action tool
+    modelactions = []
 
     def get_tool_urls(self):
         """Gets the url patterns that route each tool to a special view."""
+
         tools = {}
-        for tool in self.objectactions:
+	#Both objectactions and modelactions should be a list type (like in admin actions)
+	#Some people (and tox test units) use type instead, so to keep backward copatybility 
+	#I cast them to list.
+        for tool in list(self.objectactions) + list(self.modelactions):
             tools[tool] = getattr(self, tool)
-        my_urls = patterns('',
-            (r'^(?P<pk>\d+)/tools/(?P<tool>\w+)/$', self.admin_site.admin_view(
-                ModelToolsView.as_view(model=self.model, tools=tools)))
-        )
+
+        my_urls = []
+        if self.objectactions:
+            my_urls.append(url(r'^(?P<pk>\d+)/tools/(?P<tool>\w+)/$', 
+            self.admin_site.admin_view(ObjectToolsView.as_view(model=self.model, tools=tools))))
+
+        if self.modelactions:
+            my_urls.append(url(r'tools/(?P<tool>\w+)/$',
+	    self.admin_site.admin_view(ModelToolsView.as_view(model=self.model, tools=tools))))
+	    
         return my_urls
 
     def get_urls(self):
         """Prepends `get_urls` with our own patterns."""
+
         urls = super(DjangoObjectActions, self).get_urls()
         return self.get_tool_urls() + urls
+
+    def get_tools_context(self, tool_list):
+        """Return list that represents the tools func as a dict with extra meta."""
+
+	ret = []
+        for tool_name in tool_list:
+	    tool = getattr(self, tool_name)
+	    ret.append(dict(name = tool_name,
+	                    label=getattr(tool, 'label', tool_name),
+			    short_description=getattr(tool, 'short_description', '')))
+        return ret
 
     def render_change_form(self, request, context, **kwargs):
         """Puts `objectactions` into the context."""
 
-        def to_dict(tool_name):
-            """To represents the tool func as a dict with extra meta."""
-            tool = getattr(self, tool_name)
-            return dict(
-                name=x,
-                label=getattr(tool, 'label', x),
-                short_description=getattr(tool, 'short_description', ''))
+        if self.objectactions:
+            context['objectactions'] = self.get_tools_context(self.objectactions)
 
-        context['objectactions'] = [to_dict(x) for x in self.objectactions]
         return super(DjangoObjectActions, self).render_change_form(request,
             context, **kwargs)
 
+    def changelist_view(self, request, extra_context={}):
+        """Puts `modelactions` into the context."""
 
-class ModelToolsView(SingleObjectMixin, View):
-    """A special view that run the tool's callable."""
+        if self.modelactions:
+            extra_context['modelactions'] = self.get_tools_context(self.modelactions)
+
+        return super(DjangoObjectActions, self).changelist_view(request, extra_context)
+
+
+class ModelToolsView(View):
+    """A special view that run the tool's callable, and pass model(class) to it."""
+
     tools = {}
+    model = None
+
+    def get_object(self):
+        # Return model itself instead object instance.
+        # This method will be override by SingleObjectMixin in ObjectToolsView.
+        # By this way we can play with model(class) and model instance (object).
+        return self.model
 
     def get(self, request, **kwargs):
-        # SingleOjectMixin's `get_object`. Works because the view
-        #   is instantiated with `model` and the urlpattern has `pk`.
         obj = self.get_object()
         try:
             ret = self.tools[kwargs['tool']](request, obj)
@@ -73,8 +108,18 @@ class ModelToolsView(SingleObjectMixin, View):
         messages.info(request, message)
 
 
+class ObjectToolsView(SingleObjectMixin, ModelToolsView):
+    """A special view that run the tool's callable, and pass object instance to it."""
+
+    # Subclasssing from SingleObjectMixin set all things.
+    # SingleOjectMixin's `get_object`. Works because the view
+    #   is instantiated with `model` and the urlpattern has `pk`.
+    pass
+
+
 class QuerySetIsh(QuerySet):
     """Takes an instance and mimics it coming from a QuerySet."""
+
     def __init__(self, instance=None, *args, **kwargs):
         try:
             model = instance._meta.model
@@ -92,6 +137,7 @@ class QuerySetIsh(QuerySet):
 
 def takes_instance_or_queryset(func):
     """Decorator that makes standard actions compatible."""
+
     @wraps(func)
     def decorated_function(self, request, queryset):
         # func follows the prototype documented at:

--- a/django_object_actions/utils.py
+++ b/django_object_actions/utils.py
@@ -30,7 +30,10 @@ class DjangoObjectActions(object):
 	#Some people (and tox test units) use type instead, so to keep backward copatybility 
 	#I cast them to list.
         for tool in list(self.objectactions) + list(self.modelactions):
-            tools[tool] = getattr(self, tool)
+	    #TODO - check if this is enought to have tools splited over different instances
+	    # in case where DjangoObjectActions mixin is used with few ModelAdmin subclasses.
+	    if hasattr(self, tool):
+                tools[tool] = getattr(self, tool)
 
         my_urls = []
         if self.objectactions:
@@ -54,10 +57,12 @@ class DjangoObjectActions(object):
 
 	ret = []
         for tool_name in tool_list:
-	    tool = getattr(self, tool_name)
-	    ret.append(dict(name = tool_name,
-	                    label=getattr(tool, 'label', tool_name.replace('_', ' ')),
-			    short_description=getattr(tool, 'short_description', tool.__doc__ or '')))
+	    # TODO - The same issue with get_tool_urls - make sure that this enought.
+	    if hasattr(self, tool_name):
+                tool = getattr(self, tool_name)
+                ret.append(dict(name = tool_name,
+                                label=getattr(tool, 'label', tool_name.replace('_', ' ')),
+                                short_description=getattr(tool, 'short_description', tool.__doc__ or '')))
         return ret
 
     def render_change_form(self, request, context, **kwargs):


### PR DESCRIPTION
Hi  :)

Please check my code and add it to official tree,
I add there possibility to set action for object itself, where change_list.html template is used.
By this way we can prepare different import action, when we need new data for our models.

Also i prepare mezzanine templates(grappeli) that can be used instead django one, for user who use mezzanine cms.

In model please set:
modelactions = ['modelfunc'], as similar with objectactions.



Regards, Hetii...