### PR TITLE
Added get_object_actions() function

### DIFF
--- a/django_object_actions/utils.py
+++ b/django_object_actions/utils.py
@@ -47,9 +47,13 @@ class BaseDjangoObjectActions(object):
                 custom_attrs=custom_attrs,
             )
 
-        context['objectactions'] = [to_dict(x) for x in self.objectactions]
+        context['objectactions'] = [to_dict(x) for x in self.get_object_actions(request, context, **kwargs)]
         return super(BaseDjangoObjectActions, self).render_change_form(request,
             context, **kwargs)
+            
+            
+    def get_object_actions(self, request, context, **kwargs):
+        return self.objectactions
 
     ##################
     # CUSTOM METHODS #


### PR DESCRIPTION
Can use context['original'](the model) to return dynamic objectactions. Note that this won't affect the url setup -- modeladmin.objectactions should include all possible actions.

My use case is that models should have different actions depending on the status. For example, "publish" should only be available if article is "draft".

Unfortunately, it doesn't look like the object is available before get_urls() is called, so the actions can't be set  at that point; all possible actions must be defined.

I realized there'd be issues in modifying the self.objectactions directly (it looks like i could do it in get_readonly_fields() as it's called before render_change_form), but then I'm modifying the class's array, which caused problems.
