### PR TITLE
Use a template tag for tidier templates

### DIFF
--- a/django_object_actions/templates/django_object_actions/change_form.html
+++ b/django_object_actions/templates/django_object_actions/change_form.html
@@ -1,17 +1,7 @@
 {% extends "admin/change_form.html" %}
-
+{% load object_actions %}
 
 {% block object-tools-items %}
-  {% for tool in objectactions %}
-    <li class="objectaction-item" data-tool-name="{{ tool.name }}">
-      <a href='tools/{{ tool.name }}/' title="{{ tool.standard_attrs.title }}"
-         {% for k, v in tool.custom_attrs.items %}
-           {{ k }}="{{ v }}"
-         {% endfor %}
-         class="{{ tool.standard_attrs.class }}">
-      {{ tool.label|capfirst }}
-      </a>
-    </li>
-  {% endfor %}
+  {% object_actions %}
   {{ block.super }}
 {% endblock %}

--- a/django_object_actions/templates/django_object_actions/object_actions.html
+++ b/django_object_actions/templates/django_object_actions/object_actions.html
@@ -1,0 +1,11 @@
+{% for tool in objectactions %}
+  <li class="objectaction-item" data-tool-name="{{ tool.name }}">
+    <a href='tools/{{ tool.name }}/' title="{{ tool.standard_attrs.title }}"
+       {% for k, v in tool.custom_attrs.items %}
+         {{ k }}="{{ v }}"
+       {% endfor %}
+       class="{{ tool.standard_attrs.class }}">
+    {{ tool.label|capfirst }}
+    </a>
+  </li>
+{% endfor %}

--- a/django_object_actions/templatetags/object_actions.py
+++ b/django_object_actions/templatetags/object_actions.py
@@ -1,0 +1,13 @@
+# -*- encoding: utf8 -*-
+import re
+from django.template import Library
+
+
+register = Library()
+
+@register.inclusion_tag('django_object_actions/object_actions.html', takes_context=True)
+def object_actions(context):
+    return {
+        'objectactions': context['objectactions'],
+    }
+


### PR DESCRIPTION
If a user wants to use multiple admin extensions that all want to override the change form template they will need to incorporate all the template changes in their own change_form.html

It's therefore a good idea to keep each template customization as clean and simple as possible.

Sorry - I haven't updated the docs to mention this enhancement. If it's a blocker let me know.