### PR TITLE
update individual item for instance case

### DIFF
--- a/django_object_actions/tests/test_utils.py
+++ b/django_object_actions/tests/test_utils.py
@@ -1,12 +1,9 @@
-from django.db.models.query import QuerySet
 from django.test import TestCase
-from django.utils.unittest import expectedFailure
 
 from example_project.polls.models import Poll
 
 from ..utils import (
     BaseDjangoObjectActions,
-    QuerySetIsh,
     takes_instance_or_queryset,
 )
 
@@ -66,43 +63,6 @@ class BaseDjangoObjectActionsTest(TestCase):
         self.assertEqual(custom['nonstandard'], 'wombat')
 
 
-class QuerySetIshTest(TestCase):
-    fixtures = ['sample_data']
-
-    def setUp(self):
-        # WISHLIST don't depend on fixture
-        self.obj = Poll.objects.get(pk=1)
-
-    def test_can_turn_object_into_queryset(self):
-        qs = QuerySetIsh(self.obj)
-        self.assertEqual(qs.count(), 1)
-        self.assertEqual(qs.get(), self.obj)
-        self.assertEqual(qs.order_by('foo').get(), self.obj)
-        self.assertEqual(qs.all().get(), self.obj)
-        self.assertEqual(qs.filter().get(), self.obj)
-        self.assertEqual(qs.latest('bar'), self.obj)
-
-    def test_queryset_supports_delete(self):
-        qs = QuerySetIsh(self.obj)
-        qs.delete()
-        with self.assertRaises(Poll.DoesNotExist):
-            Poll.objects.get(pk=1)
-
-    @expectedFailure
-    def test_queryset_supports_filter(self):
-        # yeah, we don't actually support doing this, but it would be nice.
-        qs = QuerySetIsh(self.obj)
-        with self.assertRaises(Poll.DoesNotExist):
-            # this should be empty because the question is just `"hi"`
-            qs.filter(question='abra cadabra').get()
-
-    def test_queryset_supports_update(self):
-        qs = QuerySetIsh(self.obj)
-        qs.update(question='mooo')
-        self.assertEqual(Poll.objects.get(pk=1).question, 'mooo')
-        self.assertEqual(Poll.objects.get(pk=2).question, 'wut?')
-
-
 class DecoratorTest(TestCase):
     fixtures = ['sample_data']
 
@@ -129,17 +89,14 @@ class DecoratorTest(TestCase):
 
         # passing in an instance yields a queryset (using positional args)
         queryset = myfunc(None, None, self.obj)
-        self.assertIsInstance(queryset, QuerySet)
         # the resulting queryset only has one item and it's self.obj
         self.assertEqual(queryset.get(), self.obj)
 
         # passing in a queryset yields the same queryset
         queryset = myfunc(None, None, self.queryset)
-        self.assertIsInstance(queryset, QuerySet)
         self.assertEqual(queryset, self.queryset)
 
         # passing in an instance yields a queryset (using keyword args)
         queryset = myfunc(None, None, queryset=self.obj)
-        self.assertIsInstance(queryset, QuerySet)
         # the resulting queryset only has one item and it's self.obj
         self.assertEqual(queryset.get(), self.obj)

--- a/django_object_actions/tests/test_utils.py
+++ b/django_object_actions/tests/test_utils.py
@@ -100,6 +100,7 @@ class QuerySetIshTest(TestCase):
         qs = QuerySetIsh(self.obj)
         qs.update(question='mooo')
         self.assertEqual(Poll.objects.get(pk=1).question, 'mooo')
+        self.assertEqual(Poll.objects.get(pk=2).question, 'wut?')
 
 
 class DecoratorTest(TestCase):

--- a/django_object_actions/utils.py
+++ b/django_object_actions/utils.py
@@ -144,12 +144,15 @@ def takes_instance_or_queryset(func):
         # https://docs.djangoproject.com/en/dev/ref/contrib/admin/actions/#writing-action-functions
         if not isinstance(queryset, QuerySet):
             try:
-                model = queryset._meta.model
+                # Django >=1.8
+                queryset =  self.get_queryset(request).filter(pk=queryset.pk)
             except AttributeError:
-                # Django 1.5 does this instead, getting the model may be overkill
-                # we may be able to throw away all this logic
-                model = queryset._meta.concrete_model
-
-            queryset = model.objects.filter(pk=queryset.pk)
+                try:
+                    # Django >=1.6,<1.8
+                    model = queryset._meta.model
+                except AttributeError:
+                    # Django <1.6
+                    model = queryset._meta.concrete_model
+                queryset = model.objects.filter(pk=queryset.pk)
         return func(self, request, queryset)
     return decorated_function

--- a/example_project/polls/fixtures/sample_data.json
+++ b/example_project/polls/fixtures/sample_data.json
@@ -8,6 +8,14 @@
     }
   },
   {
+    "pk": 2,
+    "model": "polls.poll",
+    "fields": {
+      "pub_date": "2012-10-20T18:20:38",
+      "question": "Do you wanna build a snow man?"
+    }
+  },
+  {
     "pk": 1,
     "model": "polls.choice",
     "fields": {

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,6 @@
 Django==1.8.4
 dj-database-url==0.3.0
-django-extensions==1.5.5
+django-extensions==1.5.9
 tox==2.1.1
 factory-boy==2.5.2
 coverage==3.7.1

--- a/tox.ini
+++ b/tox.ini
@@ -17,7 +17,7 @@ commands =
     {envpython} example_project/manage.py test django_object_actions
 deps =
     dj_database_url==0.3.0
-    django-extensions==1.4.6
+    django-extensions==1.5.9
     factory-boy==2.4.1
     coveralls: coverage
     django14: Django<1.5


### PR DESCRIPTION
The docs have
```
    @takes_instance_or_queryset
    def tighten_lug_nuts(self, request, queryset):
        queryset.update(lugnuts=F('lugnuts') - 1)
```
but this updates all values since queryset seems to ignore the `_result_cache` (as proven by the test in my first commit). I'm not sure `filter(pk=...)` is the right way to implement this behavior, but `@takes_instance_or_queryset` seems dangerous as it is now.