### PR TITLE
Fix unnamed admin urls

### DIFF
--- a/django_object_actions/tests/test_utils.py
+++ b/django_object_actions/tests/test_utils.py
@@ -1,3 +1,4 @@
+import mock
 from django.test import TestCase
 
 from example_project.polls.models import Poll
@@ -11,6 +12,17 @@ from ..utils import (
 class BaseDjangoObjectActionsTest(TestCase):
     def setUp(self):
         self.instance = BaseDjangoObjectActions()
+
+    @mock.patch('django_object_actions.utils.BaseDjangoObjectActions'
+                '.admin_site', create=True)
+    def test_get_tool_urls_trivial_case(self, mock_site):
+        self.instance.model = mock.Mock(
+            **{'_meta.app_label': 'app', '_meta.model_name': 'model'})
+
+        urls = self.instance.get_tool_urls([])
+
+        self.assertEqual(len(urls), 1)
+        self.assertEqual(urls[0].name, 'app_model_change_tools')
 
     def test_get_object_actions_gets_attribute(self):
         mock_objectactions = []  # set to something mutable
@@ -26,6 +38,7 @@ class BaseDjangoObjectActionsTest(TestCase):
         # WISHLIST assert get_object_actions was called with right args
 
     def test_get_djoa_button_attrs_returns_defaults(self):
+        # TODO: use `mock`
         mock_tool = type('mock_tool', (object, ), {})
         attrs, __ = self.instance.get_djoa_button_attrs(mock_tool)
         self.assertEqual(attrs['class'], '')

--- a/django_object_actions/tests/test_utils.py
+++ b/django_object_actions/tests/test_utils.py
@@ -12,17 +12,16 @@ from ..utils import (
 class BaseDjangoObjectActionsTest(TestCase):
     def setUp(self):
         self.instance = BaseDjangoObjectActions()
+        self.instance.model = mock.Mock(
+            **{'_meta.app_label': 'app', '_meta.model_name': 'model'})
 
     @mock.patch('django_object_actions.utils.BaseDjangoObjectActions'
                 '.admin_site', create=True)
     def test_get_tool_urls_trivial_case(self, mock_site):
-        self.instance.model = mock.Mock(
-            **{'_meta.app_label': 'app', '_meta.model_name': 'model'})
-
-        urls = self.instance.get_tool_urls([])
+        urls = self.instance.get_tool_urls()
 
         self.assertEqual(len(urls), 1)
-        self.assertEqual(urls[0].name, 'app_model_change_tools')
+        self.assertEqual(urls[0].name, 'app_model_tools')
 
     def test_get_object_actions_gets_attribute(self):
         mock_objectactions = []  # set to something mutable

--- a/django_object_actions/utils.py
+++ b/django_object_actions/utils.py
@@ -47,14 +47,18 @@ class BaseDjangoObjectActions(object):
 
         for tool in self.objectactions:
             tools[tool] = getattr(self, tool)
-        my_urls = [
+        return [
             # supports pks that are numbers or uuids
             url(r'^(?P<pk>[0-9a-f\-]+)/tools/(?P<tool>\w+)/$',
                 self.admin_site.admin_view(
-                        ModelToolsView.as_view(model=self.model, tools=tools, back=change_view)),
+                    ModelToolsView.as_view(
+                        model=self.model,
+                        tools=tools,
+                        back=change_view,
+                    )
+                ),
                 name=model_tools_url_name)
         ]
-        return my_urls
 
     # EXISTING ADMIN METHODS MODIFIED
     #################################

--- a/django_object_actions/utils.py
+++ b/django_object_actions/utils.py
@@ -29,26 +29,19 @@ class BaseDjangoObjectActions(object):
     objectactions = []
     tools_view_name = None
 
-    def get_tool_urls(self, urls):
+    def get_tool_urls(self):
         """Get the url patterns that route each tool to a special view."""
         tools = {}
 
         # Look for the default change view url and use that as a template
-        change_view = None
-        end = '_change'
-        for url_pattern in urls:
-            if url_pattern.name.endswith(end):
-                model_tools_url_name = url_pattern.name[:-len(end)] + '_tools'
-                change_view = 'admin:' + url_pattern.name
-                break
-        if not change_view:
-            # Should this just replace the above?
-            base_url_name = '%s_%s_change' % (
-                self.model._meta.app_label,
-                self.model._meta.model_name,
-            )
-            model_tools_url_name = '%s_tools' % base_url_name
-            change_view = 'admin:%s' % base_url_name
+        try:
+            model_name = self.model._meta.model_name
+        except AttributeError:
+            # DJANGO15
+            model_name = self.model._meta.module_name
+        base_url_name = '%s_%s' % (self.model._meta.app_label, model_name)
+        model_tools_url_name = '%s_tools' % base_url_name
+        change_view = 'admin:%s_change' % base_url_name
 
         self.tools_view_name = 'admin:' + model_tools_url_name
 
@@ -69,7 +62,7 @@ class BaseDjangoObjectActions(object):
     def get_urls(self):
         """Prepend `get_urls` with our own patterns."""
         urls = super(BaseDjangoObjectActions, self).get_urls()
-        return self.get_tool_urls(urls) + urls
+        return self.get_tool_urls() + urls
 
     def render_change_form(self, request, context, **kwargs):
         """Put `objectactions` into the context."""

--- a/django_object_actions/utils.py
+++ b/django_object_actions/utils.py
@@ -18,7 +18,7 @@ class BaseDjangoObjectActions(object):
     tools_view_name = None
 
     def get_tool_urls(self, urls):
-        """Gets the url patterns that route each tool to a special view."""
+        """Get the url patterns that route each tool to a special view."""
         tools = {}
 
         end = '_change'
@@ -40,17 +40,16 @@ class BaseDjangoObjectActions(object):
         ]
         return my_urls
 
-    ###################################
-    # EXISTING ADMIN METHODS MODIFIED #
-    ###################################
+    # EXISTING ADMIN METHODS MODIFIED
+    #################################
 
     def get_urls(self):
-        """Prepends `get_urls` with our own patterns."""
+        """Prepend `get_urls` with our own patterns."""
         urls = super(BaseDjangoObjectActions, self).get_urls()
         return self.get_tool_urls(urls) + urls
 
     def render_change_form(self, request, context, **kwargs):
-        """Puts `objectactions` into the context."""
+        """Put `objectactions` into the context."""
 
         def to_dict(tool_name):
             """To represents the tool func as a dict with extra meta."""
@@ -71,9 +70,8 @@ class BaseDjangoObjectActions(object):
         return super(BaseDjangoObjectActions, self).render_change_form(
             request, context, **kwargs)
 
-    ##################
-    # CUSTOM METHODS #
-    ##################
+    # CUSTOM METHODS
+    ################
 
     def get_object_actions(self, request, context, **kwargs):
         """Override this to customize what actions get sent."""
@@ -112,14 +110,25 @@ class BaseDjangoObjectActions(object):
 
 
 class DjangoObjectActions(BaseDjangoObjectActions):
-    # override default change_form_template
     change_form_template = "django_object_actions/change_form.html"
 
 
 class ModelToolsView(SingleObjectMixin, View):
-    """A special view that run the tool's callable."""
-    tools = {}
+    """
+    The view that runs the tool's callable.
+
+    Attributes
+    ----------
+    back : str
+        The urlpattern name to send users back to. Defaults to the change view.
+    model : django.db.model.Model
+        The model this tool operates on
+    tools : dict
+        A mapping of tool names to views
+    """
     back = None
+    model = None
+    tools = None
 
     def get(self, request, **kwargs):
         # SingleOjectMixin's `get_object`. Works because the view
@@ -129,9 +138,11 @@ class ModelToolsView(SingleObjectMixin, View):
             tool = self.tools[kwargs['tool']]
         except KeyError:
             raise Http404(u'Tool does not exist')
+
         ret = tool(request, obj)
         if isinstance(ret, HttpResponse):
             return ret
+
         back = reverse(self.back, args=(kwargs['pk'],))
         return HttpResponseRedirect(back)
 
@@ -159,7 +170,7 @@ def takes_instance_or_queryset(func):
         if not isinstance(queryset, QuerySet):
             try:
                 # Django >=1.8
-                queryset =  self.get_queryset(request).filter(pk=queryset.pk)
+                queryset = self.get_queryset(request).filter(pk=queryset.pk)
             except AttributeError:
                 try:
                     # Django >=1.6,<1.8

--- a/django_object_actions/utils.py
+++ b/django_object_actions/utils.py
@@ -23,8 +23,8 @@ class BaseDjangoObjectActions(object):
         Write the names of the callable attributes (methods) of the model admin
         that can be used as tools.
     tools_view_name : str
-        The name of the Django Object Actions admin view. Populated by
-        `get_tool_urls`.
+        The name of the Django Object Actions admin view, including the 'admin'
+        namespace. Populated by `get_tool_urls`.
     """
     objectactions = []
     tools_view_name = None
@@ -50,7 +50,7 @@ class BaseDjangoObjectActions(object):
         return [
             # supports pks that are numbers or uuids
             url(r'^(?P<pk>[0-9a-f\-]+)/tools/(?P<tool>\w+)/$',
-                self.admin_site.admin_view(
+                self.admin_site.admin_view(  # checks permissions
                     ModelToolsView.as_view(
                         model=self.model,
                         tools=tools,
@@ -94,7 +94,19 @@ class BaseDjangoObjectActions(object):
     ################
 
     def get_object_actions(self, request, context, **kwargs):
-        """Override this to customize what actions get sent."""
+        """
+        Override this method to customize what actions get sent.
+
+        For example, to restrict actions to superusers, you could do:
+
+            class ChoiceAdmin(DjangoObjectActions, admin.ModelAdmin):
+                def get_object_actions(self, request, context, **kwargs):
+                    if request.user.is_superuser:
+                        return super(ChoiceAdmin, self).get_object_actions(
+                            request, context, **kwargs
+                        )
+                    return []
+        """
         return self.objectactions
 
     def get_djoa_button_attrs(self, tool):

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,3 +2,4 @@ dj-database-url==0.3.0
 django-extensions==1.6.1
 factory-boy==2.6.0
 coverage==4.0.3
+mock==1.3.0


### PR DESCRIPTION
Fixes #45 

#43 had some code to use named url patterns for the tool view. The name for the tool was based on the admin change view's url pattern. This PR changes the code for that to construct the url based on the historical url name... %(app)_%(model)_change instead of scanning through a list of urls.

Some small refactors and doc updates as well.