### PR TITLE
Fixed example in documentation that doesn't work as advertised.

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -128,7 +128,7 @@ account if the account is already closed)::
         objectactions = []
 
         # Actions cannot be applied to new objects (i.e. Using "add" new obj)
-        if 'original' in context and context['original'] is not None:
+        if context.get('original') is not None:
             # The obj to perform checks against to determine object actions you want to support
             obj = context['original']
 

--- a/README.rst
+++ b/README.rst
@@ -128,7 +128,7 @@ account if the account is already closed)::
         objectactions = []
 
         # Actions cannot be applied to new objects (i.e. Using "add" new obj)
-        if 'original' in context:
+        if 'original' in context and context['original'] is not None:
             # The obj to perform checks against to determine object actions you want to support
             obj = context['original']
 


### PR DESCRIPTION
The context will _always_ have an 'original' key if coming from Django's .changeform_view(), but it will be None if a new object is being added.

Running the code as provided in the example will result in AttributeErrors when the code enters the if and tried to access attributes on a None object.

I've made the if check very cautious just in case people heavily override the ModelAdmin.changeform_view() and/or the Model.__bool__() methods.