### PR TITLE
add ability redirect back active admin

### DIFF
--- a/django_object_actions/tests/test_admin.py
+++ b/django_object_actions/tests/test_admin.py
@@ -12,11 +12,12 @@ from example_project.polls.factories import CommentFactory, PollFactory
 class CommentTest(LoggedInTestCase):
     def test_action_on_a_model_with_uuid_pk_works(self):
         comment = CommentFactory()
-        url = '/admin/polls/comment/{0}/actions/hodor/'.format(comment.pk)
+        comment_url = reverse('admin:polls_comment_change', args=(comment.pk,))
+        action_url = '/admin/polls/comment/{0}/actions/hodor/'.format(comment.pk)
         # sanity check that url has a uuid
-        self.assertIn('-', url)
-        response = self.client.get(url)
-        self.assertEqual(response.status_code, 302)
+        self.assertIn('-', action_url)
+        response = self.client.get(action_url)
+        self.assertRedirects(response, comment_url)
 
 
 class ChangeTest(LoggedInTestCase):
@@ -52,3 +53,14 @@ class ChangeTest(LoggedInTestCase):
         # button is not in the admin anymore
         response = self.client.get(admin_change_url)
         self.assertNotIn(action_url, response.rendered_content)
+
+
+class MultipleAdmins(LoggedInTestCase):
+    def test_redirect_back_from_secondary_admin(self):
+        poll = PollFactory.create()
+        admin_change_url = reverse('admin:polls_poll_change', args=(poll.pk,), current_app='support')
+        action_url = '/support/polls/poll/1/actions/question_mark/'
+        self.assertTrue(admin_change_url.startswith('/support/'))
+
+        response = self.client.get(action_url)
+        self.assertRedirects(response, admin_change_url)

--- a/django_object_actions/utils.py
+++ b/django_object_actions/utils.py
@@ -124,6 +124,7 @@ class BaseDjangoObjectActions(object):
                         model=self.model,
                         actions=actions,
                         back='admin:%s_change' % base_url_name,
+                        current_app=self.admin_site.name,
                     )
                 ),
                 name=model_actions_url_name),
@@ -134,6 +135,7 @@ class BaseDjangoObjectActions(object):
                         model=self.model,
                         actions=actions,
                         back='admin:%s_changelist' % base_url_name,
+                        current_app=self.admin_site.name,
                     )
                 ),
                 # Dupe name is fine. https://code.djangoproject.com/ticket/14259
@@ -205,6 +207,7 @@ class BaseActionView(View):
     back = None
     model = None
     actions = None
+    current_app = None
 
     @property
     def view_args(self):
@@ -258,7 +261,7 @@ class ChangeActionView(SingleObjectMixin, BaseActionView):
 
     @property
     def back_url(self):
-        return reverse(self.back, args=(self.kwargs['pk'],))
+        return reverse(self.back, args=(self.kwargs['pk'],), current_app=self.current_app)
 
 
 class ChangeListActionView(MultipleObjectMixin, BaseActionView):
@@ -268,7 +271,7 @@ class ChangeListActionView(MultipleObjectMixin, BaseActionView):
 
     @property
     def back_url(self):
-        return reverse(self.back)
+        return reverse(self.back, current_app=self.current_app)
 
 
 def takes_instance_or_queryset(func):

--- a/example_project/polls/admin.py
+++ b/example_project/polls/admin.py
@@ -1,6 +1,7 @@
 from __future__ import unicode_literals
 
 from django.contrib import admin
+from django.contrib.admin import AdminSite
 from django.core.urlresolvers import reverse
 from django.db.models import F
 from django.http import HttpResponseRedirect
@@ -117,3 +118,7 @@ class CommentAdmin(DjangoObjectActions, admin.ModelAdmin):
         obj.save()
     change_actions = ('hodor', )
 admin.site.register(Comment, CommentAdmin)
+
+
+support_admin = AdminSite(name='support')
+support_admin.register(Poll, PollAdmin)

--- a/example_project/urls.py
+++ b/example_project/urls.py
@@ -2,6 +2,10 @@ from django.conf import settings
 from django.conf.urls import patterns, include, url
 
 from django.contrib import admin
+
+from example_project.polls.admin import support_admin
+
+
 admin.autodiscover()
 
 urlpatterns = patterns('',
@@ -14,6 +18,7 @@ urlpatterns = patterns('',
 
     # Uncomment the next line to enable the admin:
     url(r'^admin/', include(admin.site.urls)),
+    url(r'^support/', include(support_admin.urls)),
 )
 
 


### PR DESCRIPTION
when used several admins, you always redirect to default `admin`, should redirect back to active admin