### PR TITLE
Fix how extra context set by admins was not passed

### DIFF
--- a/django_object_actions/tests/test_admin.py
+++ b/django_object_actions/tests/test_admin.py
@@ -9,7 +9,7 @@ from .tests import LoggedInTestCase
 from example_project.polls.factories import CommentFactory, PollFactory
 
 
-class CommentTest(LoggedInTestCase):
+class CommentTests(LoggedInTestCase):
     def test_action_on_a_model_with_uuid_pk_works(self):
         comment = CommentFactory()
         url = '/admin/polls/comment/{0}/actions/hodor/'.format(comment.pk)
@@ -19,12 +19,19 @@ class CommentTest(LoggedInTestCase):
         self.assertEqual(response.status_code, 302)
 
 
-class ChangeTest(LoggedInTestCase):
+class ChangeTests(LoggedInTestCase):
     def test_buttons_load(self):
         url = '/admin/polls/choice/'
         response = self.client.get(url)
         self.assertIn('objectactions', response.context_data)
         self.assertIn('Delete_all', response.rendered_content)
+
+    def test_changelist_template_context(self):
+        url = reverse('admin:polls_poll_changelist')
+        response = self.client.get(url)
+        self.assertIn('objectactions', response.context_data)
+        self.assertIn('tools_view_name', response.context_data)
+        self.assertIn('foo', response.context_data)
 
     def test_changelist_action_view(self):
         url = '/admin/polls/choice/actions/delete_all/'
@@ -52,3 +59,14 @@ class ChangeTest(LoggedInTestCase):
         # button is not in the admin anymore
         response = self.client.get(admin_change_url)
         self.assertNotIn(action_url, response.rendered_content)
+
+
+class ChangeListTests(LoggedInTestCase):
+    def test_changelist_template_context(self):
+        poll = PollFactory()
+        url = reverse('admin:polls_poll_change', args=(poll.pk,))
+
+        response = self.client.get(url)
+        self.assertIn('objectactions', response.context_data)
+        self.assertIn('tools_view_name', response.context_data)
+        self.assertIn('foo', response.context_data)

--- a/django_object_actions/utils.py
+++ b/django_object_actions/utils.py
@@ -45,24 +45,26 @@ class BaseDjangoObjectActions(object):
         return self._get_action_urls() + urls
 
     def change_view(self, request, object_id, form_url='', extra_context=None):
-        extra_context = {
+        extra_context = extra_context or {}
+        extra_context.update({
             'objectactions': [
                 self._get_tool_dict(action) for action in
                 self.get_change_actions(request, object_id, form_url)
             ],
             'tools_view_name': self.tools_view_name,
-        }
+        })
         return super(BaseDjangoObjectActions, self).change_view(
             request, object_id, form_url, extra_context)
 
     def changelist_view(self, request, extra_context=None):
-        extra_context = {
+        extra_context = extra_context or {}
+        extra_context.update({
             'objectactions': [
                 self._get_tool_dict(action) for action in
                 self.get_changelist_actions(request)
             ],
             'tools_view_name': self.tools_view_name,
-        }
+        })
         return super(BaseDjangoObjectActions, self).changelist_view(
             request, extra_context)
 

--- a/example_project/polls/admin.py
+++ b/example_project/polls/admin.py
@@ -14,6 +14,9 @@ from .models import Choice, Poll, Comment
 class ChoiceAdmin(DjangoObjectActions, admin.ModelAdmin):
     list_display = ('poll', 'choice_text', 'votes')
 
+    # Actions
+    #########
+
     @takes_instance_or_queryset
     def increment_vote(self, request, queryset):
         queryset.update(votes=F('votes') + 1)
@@ -24,6 +27,11 @@ class ChoiceAdmin(DjangoObjectActions, admin.ModelAdmin):
         'Robert': '"); DROP TABLE Students; ',  # 327
         'class': 'addlink',
     }
+
+    actions = ['increment_vote']
+
+    # Object actions
+    ################
 
     def decrement_vote(self, request, obj):
         obj.votes -= 1
@@ -50,8 +58,6 @@ class ChoiceAdmin(DjangoObjectActions, admin.ModelAdmin):
         'raise_key_error',
     )
     changelist_actions = ('delete_all',)
-    actions = ['increment_vote']
-
 admin.site.register(Choice, ChoiceAdmin)
 
 
@@ -61,16 +67,26 @@ class ChoiceInline(admin.StackedInline):
 
 
 class PollAdmin(DjangoObjectActions, admin.ModelAdmin):
+    # List
+    ######
+
+    list_display = ('question', 'pub_date', 'was_published_recently')
+    list_filter = ['pub_date']
+    search_fields = ['question']
+    date_hierarchy = 'pub_date'
+
+    # Detail
+    ########
+
     fieldsets = [
         (None, {'fields': ['question']}),
         ('Date information',
          {'fields': ['pub_date'], 'classes': ['collapse']}),
     ]
     inlines = [ChoiceInline]
-    list_display = ('question', 'pub_date', 'was_published_recently')
-    list_filter = ['pub_date']
-    search_fields = ['question']
-    date_hierarchy = 'pub_date'
+
+    # Object actions
+    ################
 
     def delete_all_choices(self, request, obj):
         from django.shortcuts import render_to_response
@@ -104,11 +120,14 @@ class PollAdmin(DjangoObjectActions, admin.ModelAdmin):
             actions.remove('question_mark')
 
         return actions
-
 admin.site.register(Poll, PollAdmin)
 
 
 class CommentAdmin(DjangoObjectActions, admin.ModelAdmin):
+
+    # Object actions
+    ################
+
     def hodor(self, request, obj):
         if not obj.comment:
             # bail because we need a comment

--- a/example_project/polls/admin.py
+++ b/example_project/polls/admin.py
@@ -75,6 +75,10 @@ class PollAdmin(DjangoObjectActions, admin.ModelAdmin):
     search_fields = ['question']
     date_hierarchy = 'pub_date'
 
+    def changelist_view(self, request, extra_context=None):
+        extra_context = {'foo': 'changelist_view'}
+        return super(PollAdmin, self).changelist_view(request, extra_context)
+
     # Detail
     ########
 
@@ -84,6 +88,10 @@ class PollAdmin(DjangoObjectActions, admin.ModelAdmin):
          {'fields': ['pub_date'], 'classes': ['collapse']}),
     ]
     inlines = [ChoiceInline]
+
+    def change_view(self, request, object_id, form_url='', extra_context=None):
+        extra = {'foo': 'change_view'}
+        return super(PollAdmin, self).change_view(request, object_id, form_url, extra)
 
     # Object actions
     ################

--- a/example_project/polls/factories.py
+++ b/example_project/polls/factories.py
@@ -20,14 +20,23 @@ class UserFactory(factory.DjangoModelFactory):
     password = factory.PostGenerationMethodCall('set_password', 'password')
 
 
-class CommentFactory(factory.DjangoModelFactory):
-    class Meta:
-        model = models.Comment
-
-
 class PollFactory(factory.DjangoModelFactory):
     class Meta:
         model = models.Poll
 
     question = factory.LazyAttribute(lambda __: fake.sentence())
     pub_date = factory.LazyAttribute(lambda __: timezone.now())
+
+
+class ChoiceFactory(factory.DjangoModelFactory):
+    class Meta:
+        model = models.Choice
+
+    poll = factory.SubFactory(PollFactory)
+    choice_text = factory.LazyAttribute(lambda __: fake.word())
+    votes = factory.LazyAttribute(lambda __: fake.pyint())
+
+
+class CommentFactory(factory.DjangoModelFactory):
+    class Meta:
+        model = models.Comment

--- a/example_project/settings.py
+++ b/example_project/settings.py
@@ -10,7 +10,12 @@ def project_dir(*paths):
 
 
 DEBUG = True
-TEMPLATE_DEBUG = DEBUG
+TEMPLATES = [
+    {
+        'BACKEND': 'django.template.backends.django.DjangoTemplates',
+        'APP_DIRS': True,
+    },
+]
 
 DATABASES = {'default': dj_database_url.config(default='sqlite:///' +
     project_dir('example_project.db'))}


### PR DESCRIPTION
Previously, if a user set an extra context in `change_view` or `changelist_view`, it was thrown out.