### PR TITLE
support pks that are strings

### DIFF
--- a/django_object_actions/utils.py
+++ b/django_object_actions/utils.py
@@ -119,8 +119,8 @@ class BaseDjangoObjectActions(object):
         for action in chain(self.change_actions, self.changelist_actions):
             actions[action] = getattr(self, action)
         return [
-            # change, supports pks that are numbers or uuids
-            url(r'^(?P<pk>[0-9a-f\-]+)/actions/(?P<tool>\w+)/$',
+            # change, supports pks that are numbers, uuids and strings
+            url(r'^(?P<pk>[0-9a-zA-Z\-]+)/actions/(?P<tool>\w+)/$',
                 self.admin_site.admin_view(  # checks permissions
                     ChangeActionView.as_view(
                         model=self.model,


### PR DESCRIPTION
object pk can be just a string (or alpha-numeric), it's normal for some cases.
