### PR TITLE
Remove old things

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -10,8 +10,6 @@ addons:
 # Generate this env list with:
 # tox -l | awk '{ print "  - TOX_ENV="$0}'
 env:
-  - TOX_ENV=django15-py26
-  - TOX_ENV=django15-py27
   - TOX_ENV=django16-py26
   - TOX_ENV=django16-py27
   - TOX_ENV=django16-py33

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,16 +1,8 @@
 language: python
-# DELETEME TravisCI support for Python 3.5
-# https://github.com/travis-ci/travis-ci/issues/4794
-addons:
-  apt:
-    sources:
-      - deadsnakes
-    packages:
-      - python3.5
+cache: pip
 # Generate this env list with:
 # tox -l | awk '{ print "  - TOX_ENV="$0}'
 env:
-  - TOX_ENV=django16-py26
   - TOX_ENV=django16-py27
   - TOX_ENV=django16-py33
   - TOX_ENV=django17-py27
@@ -26,4 +18,3 @@ env:
 install: pip install tox coveralls
 script: tox -e $TOX_ENV
 after_success: coveralls
-sudo: false

--- a/django_object_actions/tests/__init__.py
+++ b/django_object_actions/tests/__init__.py
@@ -1,7 +1,3 @@
 # HACK to get factoryboy logging to shut up
 import logging
 logging.getLogger("factory").setLevel(logging.WARN)
-
-# DJANGO 1.5
-from .test_utils import *  # noqa
-from .tests import *  # noqa

--- a/django_object_actions/utils.py
+++ b/django_object_actions/utils.py
@@ -102,11 +102,7 @@ class BaseDjangoObjectActions(object):
         """Get the url patterns that route each action to a view."""
         actions = {}
 
-        try:
-            model_name = self.model._meta.model_name
-        except AttributeError:  # pragma: no cover
-            # DJANGO15
-            model_name = self.model._meta.module_name
+        model_name = self.model._meta.model_name
         # e.g.: polls_poll
         base_url_name = '%s_%s' % (self.model._meta.app_label, model_name)
         # e.g.: polls_poll_actions

--- a/tox.ini
+++ b/tox.ini
@@ -2,7 +2,6 @@
 # https://docs.djangoproject.com/en/dev/faq/install/#what-python-version-can-i-use-with-django
 [tox]
 envlist =
-    django15-{py26,py27},
     django16-{py26,py27,py33},
     django17-{py27,py33,py34},
     django18-{py27,py34,py35},
@@ -18,7 +17,6 @@ commands =
     {envpython} example_project/manage.py test django_object_actions
 deps =
     -rrequirements.txt
-    django15: Django<1.6
     django16: Django<1.7
     django17: Django<1.8
     django18: Django<1.9

--- a/tox.ini
+++ b/tox.ini
@@ -2,7 +2,7 @@
 # https://docs.djangoproject.com/en/dev/faq/install/#what-python-version-can-i-use-with-django
 [tox]
 envlist =
-    django16-{py26,py27,py33},
+    django16-{py27,py33},
     django17-{py27,py33,py34},
     django18-{py27,py34,py35},
     django19-{py27,py34,py35},


### PR DESCRIPTION
closes #57 and #56 

Django 1.5 and Python 2.6 are really old at this point. The test suite has been failing in those environments and there's no reason to try and fix it when they shouldn't be supported.

This makes it so CI for future pull requests will work.

#### Followup

Add official Django 1.10 support