### PR TITLE
Add Django 1.10 to 'tox' support

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,16 +1,13 @@
-media
-
-*.log
-*.pot
 *.pyc
+__pycache__
 .DS_Store
 .coverage
-.sass-cache
-
-
-.env
 .tox/
 *.db
+
+
+# Private files
+.env
 
 
 # build
@@ -18,4 +15,3 @@ MANIFEST
 build/*
 dist/*
 *.egg-info
-

--- a/.travis.yml
+++ b/.travis.yml
@@ -14,7 +14,9 @@ env:
   - TOX_ENV=django19-py27
   - TOX_ENV=django19-py34
   - TOX_ENV=django19-py35
-  - TOX_ENV=coveralls-django19-py27
+  - TOX_ENV=django110-py27
+  - TOX_ENV=django110-py35
+  - TOX_ENV=coveralls-django110-py35
 install: pip install tox coveralls
 script: tox -e $TOX_ENV
 after_success: coveralls

--- a/Makefile
+++ b/Makefile
@@ -19,8 +19,9 @@ clean: ## Remove generated files
 	rm -rf dist
 	rm -rf *.egg
 	rm -rf *.egg-info
-	find . -name "*.pyc" -delete
 	find . -name ".DS_Store" -delete
+	find . -name "*.pyc" -delete
+	find . -type d -name "__pycache__" -exec rm -rf {} \; || true
 
 install: ## Install development requirements
 	pip install -r requirements.txt

--- a/Makefile
+++ b/Makefile
@@ -27,6 +27,9 @@ install: ## Install development requirements
 	pip install -r requirements.txt
 	pip install Django tox
 
+tdd: ## Run tests with a file watcher
+	nodemon --ext py -x sh -c "python -W ignore::RuntimeWarning $(MANAGE) test --failfast django_object_actions || true"
+
 test: ## Run test suite
 	python -W ignore::RuntimeWarning $(MANAGE) test django_object_actions
 

--- a/example_project/polls/admin.py
+++ b/example_project/polls/admin.py
@@ -98,17 +98,14 @@ class PollAdmin(DjangoObjectActions, admin.ModelAdmin):
     ################
 
     def delete_all_choices(self, request, obj):
-        from django.shortcuts import render_to_response
-        from django.template import RequestContext
+        from django.shortcuts import render
 
         if request.method == 'POST':
             obj.choice_set.all().delete()
             return
 
         self.message_user(request, 'All choices deleted')
-        return render_to_response(
-            'clear_choices.html',
-            dict(object=obj), context_instance=RequestContext(request))
+        return render(request, 'clear_choices.html', {'object': obj})
     delete_all_choices.label = "Delete All Choices"
 
     def question_mark(self, request, obj):

--- a/example_project/settings.py
+++ b/example_project/settings.py
@@ -65,8 +65,14 @@ INSTALLED_APPS = (
 )
 
 
-# STFU, Django 1.7
-# To be deleted once Django 1.8 testing begins
+TEMPLATES = [
+    {
+        'BACKEND': 'django.template.backends.django.DjangoTemplates',
+        'APP_DIRS': True,
+    },
+]
+
+# DJANGO1.7
 SILENCED_SYSTEM_CHECKS = [
     '1_7.W001',
 ]

--- a/example_project/urls.py
+++ b/example_project/urls.py
@@ -1,31 +1,26 @@
 from django.conf import settings
-from django.conf.urls import patterns, include, url
-
+from django.conf.urls import include, url
 from django.contrib import admin
+from django.views.static import serve
+try:
+    from django.conf.urls import patterns
+except ImportError:
+    # DJANGO1.6 DJANGO1.7
+    # https://docs.djangoproject.com/en/1.8/releases/1.8/#django-conf-urls-patterns
+    def patterns(__, *urlpatterns):
+        return urlpatterns
 
 from example_project.polls.admin import support_admin
 
 
 admin.autodiscover()
 
-urlpatterns = patterns('',
-    # Examples:
-    # url(r'^$', 'example_project.views.home', name='home'),
-    # url(r'^example_project/', include('example_project.foo.urls')),
-
-    # Uncomment the admin/doc line below to enable admin documentation:
-    # url(r'^admin/doc/', include('django.contrib.admindocs.urls')),
-
-    # Uncomment the next line to enable the admin:
+urlpatterns = patterns(
+    '',
     url(r'^admin/', include(admin.site.urls)),
     url(r'^support/', include(support_admin.urls)),
+    # serve media
+    url(r'^media/(?P<path>.*)$', serve, {
+        'document_root': settings.MEDIA_ROOT,
+    }),
 )
-
-
-# serve media
-if settings.DEBUG:
-    urlpatterns += patterns('',
-        url(r'^media/(?P<path>.*)$', 'django.views.static.serve', {
-            'document_root': settings.MEDIA_ROOT,
-        }),
-   )

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,6 @@
-dj-database-url==0.4.0
-django-extensions==1.6.1
-factory-boy==2.6.1
-coverage==4.0.3
-mock==1.3.0
+dj-database-url==0.4.1
+# Can upgrade once we lose DJANGO1.7
+django-extensions==1.6.7
+factory-boy==2.7.0
+coverage==4.2
+mock==2.0.0

--- a/tox.ini
+++ b/tox.ini
@@ -6,8 +6,9 @@ envlist =
     django17-{py27,py33,py34},
     django18-{py27,py34,py35},
     django19-{py27,py34,py35},
+    django110-{py27,py35},
     # run one of the tests again but with coverage
-    coveralls-django19-py27,
+    coveralls-django110-py35,
 skipsdist = True
 
 [testenv]
@@ -21,7 +22,8 @@ deps =
     django17: Django<1.8
     django18: Django<1.9
     django19: Django<1.10
+    django110: Django<1.11
 
-[testenv:coveralls-django18-py27]
+[testenv:coveralls-django110-py35]
 commands =
     coverage run example_project/manage.py test django_object_actions


### PR DESCRIPTION
Mostly involves updating syntax in the example project. No changes required in the `django_object_actions` app. Though I really should add an appconfig I suppose.