### PR TITLE
Fix faker in requirements

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -2,5 +2,6 @@ dj-database-url==0.4.1
 # Can upgrade once we lose DJANGO1.7
 django-extensions==1.6.7
 factory-boy==2.7.0
+faker==0.7.7
 coverage==4.2
 mock==2.0.0


### PR DESCRIPTION
Tests failed with
```
ImportError: The ``fake-factory`` package is now called ``Faker``.

Please update your requirements.
```
From faker docs:
The `fake-factory` package was deprecated on December 15th, 2016.
Use the `Faker` package instead.

This commit fixes it