### PR TITLE
Get rid of Django 2.0 DeprecationWarning

### DIFF
--- a/django_object_actions/tests/test_admin.py
+++ b/django_object_actions/tests/test_admin.py
@@ -3,9 +3,13 @@ Integration tests that actually try and use the tools setup in admin.py
 """
 from __future__ import unicode_literals
 
-from django.core.urlresolvers import reverse
 from django.http import HttpResponse
 from mock import patch
+
+try:
+    from django.urls import reverse
+except ImportError:
+    from django.core.urlresolvers import reverse  # < django 1.10
 
 from .tests import LoggedInTestCase
 from example_project.polls.factories import CommentFactory, PollFactory

--- a/django_object_actions/tests/tests.py
+++ b/django_object_actions/tests/tests.py
@@ -1,4 +1,7 @@
-from django.core.urlresolvers import reverse
+try:
+    from django.urls import reverse
+except ImportError:
+    from django.core.urlresolvers import reverse  # < django 1.10
 from django.test import TestCase
 
 from example_project.polls.factories import UserFactory

--- a/django_object_actions/utils.py
+++ b/django_object_actions/utils.py
@@ -5,13 +5,17 @@ from itertools import chain
 
 from django.conf.urls import url
 from django.contrib import messages
-from django.core.urlresolvers import reverse
 from django.db.models.query import QuerySet
 from django.http import Http404, HttpResponseRedirect
 from django.http.response import HttpResponseBase
 from django.views.generic import View
 from django.views.generic.detail import SingleObjectMixin
 from django.views.generic.list import MultipleObjectMixin
+
+try:
+    from django.urls import reverse
+except ImportError:
+    from django.core.urlresolvers import reverse  # < django 1.10
 
 
 class BaseDjangoObjectActions(object):

--- a/example_project/polls/admin.py
+++ b/example_project/polls/admin.py
@@ -2,12 +2,13 @@ from __future__ import unicode_literals
 
 from django.contrib import admin
 from django.contrib.admin import AdminSite
+from django.db.models import F
+from django.http import HttpResponseRedirect
+
 try:
     from django.urls import reverse
 except ImportError:
     from django.core.urlresolvers import reverse  # < django 1.10
-from django.db.models import F
-from django.http import HttpResponseRedirect
 
 from django_object_actions import (
     DjangoObjectActions, takes_instance_or_queryset)

--- a/example_project/polls/admin.py
+++ b/example_project/polls/admin.py
@@ -2,7 +2,10 @@ from __future__ import unicode_literals
 
 from django.contrib import admin
 from django.contrib.admin import AdminSite
-from django.core.urlresolvers import reverse
+try:
+    from django.urls import reverse
+except ImportError:
+    from django.core.urlresolvers import reverse  # < django 1.10
 from django.db.models import F
 from django.http import HttpResponseRedirect
 

--- a/example_project/settings.py
+++ b/example_project/settings.py
@@ -69,6 +69,11 @@ TEMPLATES = [
     {
         'BACKEND': 'django.template.backends.django.DjangoTemplates',
         'APP_DIRS': True,
+        'OPTIONS': {
+            'context_processors': [
+                'django.contrib.auth.context_processors.auth',
+            ],
+        },
     },
 ]
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,6 @@
 dj-database-url==0.4.1
 # Can upgrade once we lose DJANGO1.7
 django-extensions==1.6.7
-factory-boy==2.7.0
+factory-boy==2.8.1
 coverage==4.2
 mock==2.0.0

--- a/tox.ini
+++ b/tox.ini
@@ -7,6 +7,7 @@ envlist =
     django18-{py27,py34,py35},
     django19-{py27,py34,py35},
     django110-{py27,py35},
+    django111-{py27,py35},
     # run one of the tests again but with coverage
     coveralls-django110-py35,
 skipsdist = True
@@ -23,6 +24,7 @@ deps =
     django18: Django<1.9
     django19: Django<1.10
     django110: Django<1.11
+    django111: Django>=1.11rc1,<2.0
 
 [testenv:coveralls-django110-py35]
 commands =


### PR DESCRIPTION
Get rid of Django 2.0 DeprecationWarning and add 1.11 tox env.
It also fixes faker dependency addressed in #76