### PR TITLE
Add support for Django 2.0

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,27 +1,37 @@
 language: python
-# Workaround for Python 3.6 missing
-python: "3.6"
 cache: pip
-# Generate this env list with:
-# tox -l | awk '{ print "  - TOX_ENV="$0}'
-env:
-  - TOX_ENV=django16-py27
-  - TOX_ENV=django16-py33
-  - TOX_ENV=django17-py27
-  - TOX_ENV=django17-py33
-  - TOX_ENV=django17-py34
-  - TOX_ENV=django18-py27
-  - TOX_ENV=django18-py34
-  - TOX_ENV=django18-py35
-  - TOX_ENV=django19-py27
-  - TOX_ENV=django19-py34
-  - TOX_ENV=django19-py35
-  - TOX_ENV=django110-py27
-  - TOX_ENV=django110-py35
-  - TOX_ENV=django111-py27
-  - TOX_ENV=django111-py35
-  - TOX_ENV=django111-py36
-  - TOX_ENV=coveralls-django111-py36
+
+matrix:
+  include:
+    - python: 2.7
+      env: TOX_ENV=django18-py27
+    - python: 3.4
+      env: TOX_ENV=django18-py34
+    - python: 3.5
+      env: TOX_ENV=django18-py35
+    - python: 2.7
+      env: TOX_ENV=django19-py27
+    - python: 3.4
+      env: TOX_ENV=django19-py34
+    - python: 3.5
+      env: TOX_ENV=django19-py35
+    - python: 2.7
+      env: TOX_ENV=django110-py27
+    - python: 3.5
+      env: TOX_ENV=django110-py35
+    - python: 2.7
+      env: TOX_ENV=django111-py27
+    - python: 3.5
+      env: TOX_ENV=django111-py35
+    - python: 3.6
+      env: TOX_ENV=django111-py36
+    - python: 3.5
+      env: TOX_ENV=django20-py35
+    - python: 3.6
+      env: TOX_ENV=django20-py36
+    - python: 3.6
+      env: TOX_ENV=coveralls-django111-py36
+
 install: pip install tox coveralls
 script: tox -e $TOX_ENV
 after_success: coveralls

--- a/Makefile
+++ b/Makefile
@@ -50,7 +50,7 @@ resetdb: ## Delete and then recreate the dev sqlite database
 
 .PHONY: build
 build: ## Build a full set of Docker images
-build: build/1.11.1 build/1.10.7 build/1.9.13 build/1.8.18 build/1.7.11 build/1.6.11
+build: build/2.0 build/1.11.1 build/1.10.7 build/1.9.13 build/1.8.18
 
 build/%:
 	docker build --build-arg DJANGO_VERSION=$* \
@@ -62,6 +62,7 @@ run/%:
 	docker run --rm -p 8000:8000 -it $(IMAGE):$*
 
 docker/publish: ## Publish Docker images to the hub
+	docker push $(IMAGE):2.0
 	docker push $(IMAGE):1.11
 	docker push $(IMAGE):1.10
 	docker push $(IMAGE):1.9

--- a/example_project/polls/migrations/0001_initial.py
+++ b/example_project/polls/migrations/0001_initial.py
@@ -4,7 +4,6 @@ from __future__ import unicode_literals
 
 from django.db import migrations, models
 import django.db.models.deletion
-import django_extensions.db.fields
 
 
 class Migration(migrations.Migration):
@@ -26,7 +25,7 @@ class Migration(migrations.Migration):
         migrations.CreateModel(
             name='Comment',
             fields=[
-                ('uuid', django_extensions.db.fields.UUIDField(blank=True, editable=False, primary_key=True, serialize=False)),
+                ('uuid', models.UUIDField(editable=False, primary_key=True, serialize=False)),
                 ('comment', models.TextField(blank=True, null=True)),
             ],
         ),

--- a/example_project/polls/models.py
+++ b/example_project/polls/models.py
@@ -1,8 +1,8 @@
 import datetime
+import uuid
 
 from django.db import models
 from django.utils import timezone
-from django_extensions.db.fields import UUIDField
 
 
 class Poll(models.Model):
@@ -20,7 +20,7 @@ class Poll(models.Model):
 
 
 class Choice(models.Model):
-    poll = models.ForeignKey(Poll)
+    poll = models.ForeignKey(Poll, on_delete=models.CASCADE)
     choice_text = models.CharField(max_length=200)
     votes = models.IntegerField()
 
@@ -29,7 +29,7 @@ class Choice(models.Model):
 
 
 class Comment(models.Model):
-    uuid = UUIDField(primary_key=True)
+    uuid = models.UUIDField(primary_key=True, default=uuid.uuid4, editable=False)
     comment = models.TextField(null=True, blank=True)
 
     def __unicode__(self):

--- a/example_project/settings.py
+++ b/example_project/settings.py
@@ -36,8 +36,7 @@ SECRET_KEY = 'lolimasekrit'
 
 ROOT_URLCONF = 'example_project.urls'
 
-
-MIDDLEWARE_CLASSES = (
+MIDDLEWARE_CLASSES = MIDDLEWARE = (
     'django.contrib.sessions.middleware.SessionMiddleware',
     'django.middleware.common.CommonMiddleware',
     'django.middleware.csrf.CsrfViewMiddleware',

--- a/example_project/urls.py
+++ b/example_project/urls.py
@@ -1,26 +1,18 @@
-from django.conf import settings
-from django.conf.urls import include, url
+from django import VERSION
+from django.conf.urls import url
 from django.contrib import admin
-from django.views.static import serve
-try:
-    from django.conf.urls import patterns
-except ImportError:
-    # DJANGO1.6 DJANGO1.7
-    # https://docs.djangoproject.com/en/1.8/releases/1.8/#django-conf-urls-patterns
-    def patterns(__, *urlpatterns):
-        return urlpatterns
-
 from example_project.polls.admin import support_admin
 
+if VERSION[0] == 1 and VERSION[1] <= 8:
+    from django.conf.urls import include
+else:
+    # DJANGO1.9
+    # https://docs.djangoproject.com/en/2.0/releases/1.9/#passing-a-3-tuple-or-an-app-name-to-include
+    def include(urls):
+        return urls
 
-admin.autodiscover()
 
-urlpatterns = patterns(
-    '',
+urlpatterns = [
     url(r'^admin/', include(admin.site.urls)),
     url(r'^support/', include(support_admin.urls)),
-    # serve media
-    url(r'^media/(?P<path>.*)$', serve, {
-        'document_root': settings.MEDIA_ROOT,
-    }),
-)
+]

--- a/requirements.in
+++ b/requirements.in
@@ -1,7 +1,7 @@
 dj-database-url
-# Can upgrade once we lose DJANGO1.7
-django-extensions==1.6.7
+django-extensions==2.0.0
 factory-boy
 Faker
 coverage
 mock
+uuid

--- a/requirements.txt
+++ b/requirements.txt
@@ -6,10 +6,12 @@
 #
 coverage==4.4.1
 dj-database-url==0.4.2
-django-extensions==1.6.7
+django-extensions==2.0.0
 factory-boy==2.8.1
-faker==0.7.17             # via factory-boy
+faker==0.7.17
 mock==2.0.0
 pbr==3.0.1                # via mock
 python-dateutil==2.6.0    # via faker
 six==1.10.0               # via django-extensions, faker, mock, python-dateutil
+typing==3.6.4             # via django-extensions
+uuid==1.30

--- a/tox.ini
+++ b/tox.ini
@@ -2,12 +2,11 @@
 # https://docs.djangoproject.com/en/dev/faq/install/#what-python-version-can-i-use-with-django
 [tox]
 envlist =
-    django16-{py27,py33},
-    django17-{py27,py33,py34},
     django18-{py27,py34,py35},
     django19-{py27,py34,py35},
     django110-{py27,py35},
     django111-{py27,py35,py36},
+    django20-{py35,py36},
     # run one of the tests again but with coverage
     coveralls-django111-py36,
 skipsdist = True
@@ -19,12 +18,11 @@ commands =
     {envpython} example_project/manage.py test django_object_actions
 deps =
     -rrequirements.txt
-    django16: Django<1.7
-    django17: Django<1.8
     django18: Django<1.9
     django19: Django<1.10
     django110: Django<1.11
     django111: Django<1.12
+    django20: Django<2.1
 
 [testenv:coveralls-django111-py36]
 commands =


### PR DESCRIPTION
Adding support for Django 2.0+, and removing support for Django versions up to 1.8, the oldest supported LTS release. This allows us to replace the now deprecated django-extensions UUIDField with the Django native version, and drop a couple of other hacks. Resolves #84 