### PR TITLE
Return to preserved filters on change_list after object action

### DIFF
--- a/django_object_actions/templates/django_object_actions/change_form.html
+++ b/django_object_actions/templates/django_object_actions/change_form.html
@@ -2,18 +2,17 @@
 {% load add_preserved_filters from admin_urls %}
 
 {% block object-tools-items %}
-    {% for tool in objectactions %}
+  {% for tool in objectactions %}
     <li class="objectaction-item" data-tool-name="{{ tool.name }}">
-        {% url tools_view_name pk=object_id tool=tool.name as action_url %}
-        <a href="{% add_preserved_filters action_url %}"
-        title="{{ tool.standard_attrs.title }}"
-            {% for k, v in tool.custom_attrs.items %}
-                {{ k }}="{{ v }}"
-            {% endfor %}
-        class="{{ tool.standard_attrs.class }}">
-        {{ tool.label|capfirst }}
-        </a>
+      {% url tools_view_name pk=object_id tool=tool.name as action_url %}
+      <a href="{% add_preserved_filters action_url %}" title="{{ tool.standard_attrs.title }}"
+         {% for k, v in tool.custom_attrs.items %}
+           {{ k }}="{{ v }}"
+         {% endfor %}
+         class="{{ tool.standard_attrs.class }}">
+      {{ tool.label|capfirst }}
+      </a>
     </li>
-    {% endfor %}
-    {{ block.super }}
+  {% endfor %}
+  {{ block.super }}
 {% endblock %}

--- a/django_object_actions/templates/django_object_actions/change_form.html
+++ b/django_object_actions/templates/django_object_actions/change_form.html
@@ -1,17 +1,19 @@
 {% extends "admin/change_form.html" %}
-
+{% load admin_urls %}
 
 {% block object-tools-items %}
-  {% for tool in objectactions %}
+    {% for tool in objectactions %}
     <li class="objectaction-item" data-tool-name="{{ tool.name }}">
-      <a href='{% url tools_view_name pk=object_id tool=tool.name %}' title="{{ tool.standard_attrs.title }}"
-         {% for k, v in tool.custom_attrs.items %}
-           {{ k }}="{{ v }}"
-         {% endfor %}
-         class="{{ tool.standard_attrs.class }}">
-      {{ tool.label|capfirst }}
-      </a>
+        {% url tools_view_name pk=object_id tool=tool.name as action_url %}
+        <a href="{% add_preserved_filters action_url %}"
+        title="{{ tool.standard_attrs.title }}"
+            {% for k, v in tool.custom_attrs.items %}
+                {{ k }}="{{ v }}"
+            {% endfor %}
+        class="{{ tool.standard_attrs.class }}">
+        {{ tool.label|capfirst }}
+        </a>
     </li>
-  {% endfor %}
-  {{ block.super }}
+    {% endfor %}
+    {{ block.super }}
 {% endblock %}

--- a/django_object_actions/templates/django_object_actions/change_form.html
+++ b/django_object_actions/templates/django_object_actions/change_form.html
@@ -1,5 +1,5 @@
 {% extends "admin/change_form.html" %}
-{% load admin_urls %}
+{% load add_preserved_filters from admin_urls %}
 
 {% block object-tools-items %}
     {% for tool in objectactions %}

--- a/django_object_actions/templates/django_object_actions/change_list.html
+++ b/django_object_actions/templates/django_object_actions/change_list.html
@@ -2,18 +2,17 @@
 {% load add_preserved_filters from admin_urls %}
 
 {% block object-tools-items %}
-    {% for tool in objectactions %}
+  {% for tool in objectactions %}
     <li class="objectaction-item" data-tool-name="{{ tool.name }}">
-        {% url tools_view_name pk=object_id tool=tool.name as action_url %}
-        <a href="{% add_preserved_filters action_url %}"
-        title="{{ tool.standard_attrs.title }}"
-            {% for k, v in tool.custom_attrs.items %}
-                {{ k }}="{{ v }}"
-            {% endfor %}
-        class="{{ tool.standard_attrs.class }}">
-        {{ tool.label|capfirst }}
-        </a>
+      {% url tools_view_name pk=object_id tool=tool.name as action_url %}
+      <a href="{% add_preserved_filters action_url %}" title="{{ tool.standard_attrs.title }}"
+         {% for k, v in tool.custom_attrs.items %}
+           {{ k }}="{{ v }}"
+         {% endfor %}
+         class="{{ tool.standard_attrs.class }}">
+      {{ tool.label|capfirst }}
+      </a>
     </li>
-    {% endfor %}
-    {{ block.super }}
+  {% endfor %}
+  {{ block.super }}
 {% endblock %}

--- a/django_object_actions/templates/django_object_actions/change_list.html
+++ b/django_object_actions/templates/django_object_actions/change_list.html
@@ -1,17 +1,19 @@
 {% extends "admin/change_list.html" %}
-
+{% load admin_urls %}
 
 {% block object-tools-items %}
-  {% for tool in objectactions %}
+    {% for tool in objectactions %}
     <li class="objectaction-item" data-tool-name="{{ tool.name }}">
-      <a href='{% url tools_view_name tool=tool.name %}' title="{{ tool.standard_attrs.title }}"
-         {% for k, v in tool.custom_attrs.items %}
-           {{ k }}="{{ v }}"
-         {% endfor %}
-         class="{{ tool.standard_attrs.class }}">
-      {{ tool.label|capfirst }}
-      </a>
+        {% url tools_view_name pk=object_id tool=tool.name as action_url %}
+        <a href="{% add_preserved_filters action_url %}"
+        title="{{ tool.standard_attrs.title }}"
+            {% for k, v in tool.custom_attrs.items %}
+                {{ k }}="{{ v }}"
+            {% endfor %}
+        class="{{ tool.standard_attrs.class }}">
+        {{ tool.label|capfirst }}
+        </a>
     </li>
-  {% endfor %}
-  {{ block.super }}
+    {% endfor %}
+    {{ block.super }}
 {% endblock %}

--- a/django_object_actions/templates/django_object_actions/change_list.html
+++ b/django_object_actions/templates/django_object_actions/change_list.html
@@ -1,5 +1,5 @@
 {% extends "admin/change_list.html" %}
-{% load admin_urls %}
+{% load add_preserved_filters from admin_urls %}
 
 {% block object-tools-items %}
     {% for tool in objectactions %}


### PR DESCRIPTION
If you want to filter change_list by some conditions, then open each object and run some object action there, you will be returned to change_list with the same preserved filters.

Fix #83