### PR TITLE
Make default labels prettier

### DIFF
--- a/django_object_actions/utils.py
+++ b/django_object_actions/utils.py
@@ -151,7 +151,7 @@ class BaseDjangoObjectActions(object):
         standard_attrs, custom_attrs = self._get_button_attrs(tool)
         return dict(
             name=tool_name,
-            label=getattr(tool, 'label', tool_name),
+            label=getattr(tool, 'label', tool_name.replace('_', ' ').capitalize()),
             standard_attrs=standard_attrs,
             custom_attrs=custom_attrs,
         )


### PR DESCRIPTION
With this change the default label changes from `some_action` to `Some action`