### PR TITLE
fix: changelist action links had no 'href'

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -11,6 +11,10 @@ quickstart: resetdb
 	python $(MANAGE) createsuperuser
 	python $(MANAGE) runserver
 
+dev: ## Run the example project
+	@echo Browse at http://localhost:8000/admin/
+	python $(MANAGE) runserver
+
 clean: ## Remove generated files
 	rm -rf .coverage
 	rm -rf .tox

--- a/django_object_actions/templates/django_object_actions/change_list.html
+++ b/django_object_actions/templates/django_object_actions/change_list.html
@@ -4,7 +4,7 @@
 {% block object-tools-items %}
   {% for tool in objectactions %}
     <li class="objectaction-item" data-tool-name="{{ tool.name }}">
-      {% url tools_view_name pk=object_id tool=tool.name as action_url %}
+      {% url tools_view_name tool=tool.name as action_url %}
       <a href="{% add_preserved_filters action_url %}" title="{{ tool.standard_attrs.title }}"
          {% for k, v in tool.custom_attrs.items %}
            {{ k }}="{{ v }}"

--- a/django_object_actions/tests/test_urls.py
+++ b/django_object_actions/tests/test_urls.py
@@ -11,6 +11,8 @@ from .tests import LoggedInTestCase
 
 class ChangeListTests(LoggedInTestCase):
     def test_changelist_action_is_rendered(self):
-        response = self.client.get(reverse('admin:polls_choice_changelist'))
+        response = self.client.get(reverse("admin:polls_choice_changelist"))
         self.assertEqual(response.status_code, 200)
-        self.assertIn(b'href="/admin/polls/choice/actions/delete_all/"', response.content)
+        self.assertIn(
+            b'href="/admin/polls/choice/actions/delete_all/"', response.content
+        )

--- a/django_object_actions/tests/test_urls.py
+++ b/django_object_actions/tests/test_urls.py
@@ -1,0 +1,16 @@
+"""
+Integration tests
+"""
+try:
+    from django.urls import reverse
+except ImportError:
+    from django.core.urlresolvers import reverse  # < DJANGO1.10
+
+from .tests import LoggedInTestCase
+
+
+class ChangeListTests(LoggedInTestCase):
+    def test_changelist_action_is_rendered(self):
+        response = self.client.get(reverse('admin:polls_choice_changelist'))
+        self.assertEqual(response.status_code, 200)
+        self.assertIn(b'href="/admin/polls/choice/actions/delete_all/"', response.content)

--- a/requirements.txt
+++ b/requirements.txt
@@ -4,13 +4,13 @@
 #
 #    pip-compile requirements.in
 #
-coverage==4.5.3
+coverage==4.5.4
 dj-database-url==0.5.0
-django-extensions==2.1.6
+django-extensions==2.2.3
 factory-boy==2.12.0
-faker==1.0.7              # via factory-boy
+faker==2.0.2              # via factory-boy
 mock==3.0.5
 python-dateutil==2.8.0    # via faker
 six==1.12.0               # via django-extensions, faker, mock, python-dateutil
-text-unidecode==1.2       # via faker
+text-unidecode==1.3       # via faker
 uuid==1.30


### PR DESCRIPTION
I probably copy pasted something wrong and brought an extra arg into the `reverse`, so `reverse` never found anything and the actions in the changelist never rendered with a `href`. This makes the args match the url definition so these buttons work again.

Thanks to @mvbrn for the original fix.

closes #96 