### PR TITLE
feat: Drop Python 2 support

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,17 +7,11 @@ script: tox -e $TOX_ENV
 jobs:
   include:
     - stage: test
-      python: 2.7
-      env: TOX_ENV=django18-py27
-    - stage: test
       python: 3.4
       env: TOX_ENV=django18-py34
     - stage: test
       python: 3.5
       env: TOX_ENV=django18-py35
-    - stage: test
-      python: 2.7
-      env: TOX_ENV=django19-py27
     - stage: test
       python: 3.4
       env: TOX_ENV=django19-py34
@@ -25,14 +19,8 @@ jobs:
       python: 3.5
       env: TOX_ENV=django19-py35
     - stage: test
-      python: 2.7
-      env: TOX_ENV=django110-py27
-    - stage: test
       python: 3.5
       env: TOX_ENV=django110-py35
-    - stage: test
-      python: 2.7
-      env: TOX_ENV=django111-py27
     - stage: test
       python: 3.5
       env: TOX_ENV=django111-py35

--- a/Makefile
+++ b/Makefile
@@ -90,9 +90,10 @@ version:
 # 1. bump VERSION
 # 2. `make version`
 # 3. `make release`
-# 4. `git push --tags origin master`
+# 4. `git push --follow-tags origin master`
 # 5. `chandler push`
 # 6. `make build docker/publish`
-release:
-	@-pip install wheel > /dev/null
-	python setup.py sdist bdist_wheel upload
+release: clean
+	@-pip install twine wheel > /dev/null
+	python setup.py sdist bdist_wheel
+	twine upload dist/*

--- a/django_object_actions/tests/test_admin.py
+++ b/django_object_actions/tests/test_admin.py
@@ -1,8 +1,6 @@
 """
 Integration tests that actually try and use the tools setup in admin.py
 """
-from __future__ import unicode_literals
-
 from django.http import HttpResponse
 from mock import patch
 

--- a/django_object_actions/tests/test_utils.py
+++ b/django_object_actions/tests/test_utils.py
@@ -1,6 +1,6 @@
-import mock
-from django.test import TestCase
+from unittest import mock
 
+from django.test import TestCase
 from example_project.polls.models import Poll
 
 from ..utils import BaseDjangoObjectActions, BaseActionView, takes_instance_or_queryset

--- a/django_object_actions/utils.py
+++ b/django_object_actions/utils.py
@@ -1,5 +1,3 @@
-from __future__ import unicode_literals
-
 from functools import wraps
 from itertools import chain
 

--- a/example_project/polls/admin.py
+++ b/example_project/polls/admin.py
@@ -1,5 +1,3 @@
-from __future__ import unicode_literals
-
 from django.contrib import admin
 from django.contrib.admin import AdminSite
 from django.db.models import F

--- a/example_project/polls/models.py
+++ b/example_project/polls/models.py
@@ -1,5 +1,5 @@
 import datetime
-import uuid
+from uuid import uuid4
 
 from django.db import models
 from django.utils import timezone
@@ -30,7 +30,7 @@ class Choice(models.Model):
 
 
 class Comment(models.Model):
-    uuid = models.UUIDField(primary_key=True, default=uuid.uuid4, editable=False)
+    uuid = models.UUIDField(primary_key=True, default=uuid4, editable=False)
     comment = models.TextField(null=True, blank=True)
 
     def __str__(self):

--- a/requirements.in
+++ b/requirements.in
@@ -2,5 +2,3 @@ dj-database-url
 django-extensions
 factory-boy
 coverage
-# DELETEME after python 2.7 is dropped
-uuid

--- a/requirements.in
+++ b/requirements.in
@@ -3,5 +3,4 @@ django-extensions
 factory-boy
 coverage
 # DELETEME after python 2.7 is dropped
-mock
 uuid

--- a/setup.py
+++ b/setup.py
@@ -19,8 +19,6 @@ setup(
         "Intended Audience :: Developers",
         "License :: OSI Approved :: Apache Software License",
         "Operating System :: OS Independent",
-        "Programming Language :: Python :: 2",
-        "Programming Language :: Python :: 2.7",
         "Programming Language :: Python :: 3",
         "Programming Language :: Python :: 3.4",
         "Programming Language :: Python :: 3.5",

--- a/tox.ini
+++ b/tox.ini
@@ -2,10 +2,10 @@
 # https://docs.djangoproject.com/en/dev/faq/install/#what-python-version-can-i-use-with-django
 [tox]
 envlist =
-    django18-{py27,py34,py35},
-    django19-{py27,py34,py35},
-    django110-{py27,py35},
-    django111-{py27,py35,py36},
+    django18-{py34,py35},
+    django19-{py34,py35},
+    django110-{py35},
+    django111-{py35,py36},
     django20-{py34,py35,py36,py37},
     django21-{py35,py36,py37},
     django22-{py36,py37},


### PR DESCRIPTION
BREAKING CHANGE: This release drops Python 2 support

Django has [dropped Python 2 support](https://docs.djangoproject.com/en/2.2/releases/2.0/#python-compatibility) ever since Django 2.0 (December 2, 2017). With Django 3.0 coming very soon and Python 2 reaching end of life, it doesn't make sense to continue supporting Python 2.