### PR TITLE
chore: add Django 3.2 to test grid

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -63,6 +63,9 @@ jobs:
     - stage: test
       python: 3.8
       env: TOX_ENV=django31-py38
+    - stage: test
+      python: 3.8
+      env: TOX_ENV=django32-py38
     - stage: lint
       install: pip install black
       script: black --check .

--- a/django_object_actions/tests/test_admin.py
+++ b/django_object_actions/tests/test_admin.py
@@ -3,7 +3,7 @@ Integration tests that actually try and use the tools setup in admin.py
 """
 from django.contrib.admin.utils import quote
 from django.http import HttpResponse
-from mock import patch
+from unittest.mock import patch
 
 try:
     from django.urls import reverse

--- a/example_project/polls/factories.py
+++ b/example_project/polls/factories.py
@@ -8,7 +8,7 @@ from django.utils import timezone
 from . import models
 
 
-class UserFactory(factory.DjangoModelFactory):
+class UserFactory(factory.django.DjangoModelFactory):
     class Meta:
         model = get_user_model()
 
@@ -19,7 +19,7 @@ class UserFactory(factory.DjangoModelFactory):
     password = factory.PostGenerationMethodCall("set_password", "password")
 
 
-class PollFactory(factory.DjangoModelFactory):
+class PollFactory(factory.django.DjangoModelFactory):
     class Meta:
         model = models.Poll
 
@@ -27,7 +27,7 @@ class PollFactory(factory.DjangoModelFactory):
     pub_date = factory.LazyAttribute(lambda __: timezone.now())
 
 
-class ChoiceFactory(factory.DjangoModelFactory):
+class ChoiceFactory(factory.django.DjangoModelFactory):
     class Meta:
         model = models.Choice
 
@@ -36,7 +36,7 @@ class ChoiceFactory(factory.DjangoModelFactory):
     votes = factory.Faker("pyint")
 
 
-class CommentFactory(factory.DjangoModelFactory):
+class CommentFactory(factory.django.DjangoModelFactory):
     class Meta:
         model = models.Comment
 
@@ -47,7 +47,7 @@ def get_random_string(length):
     return result_str
 
 
-class RelatedDataFactory(factory.DjangoModelFactory):
+class RelatedDataFactory(factory.django.DjangoModelFactory):
     id = factory.lazy_attribute(
         lambda __: "{}:{}-{}!{}".format(
             get_random_string(2),

--- a/example_project/settings.py
+++ b/example_project/settings.py
@@ -16,6 +16,7 @@ DATABASES = {
         default="sqlite:///" + project_dir("example_project.db")
     )
 }
+DEFAULT_AUTO_FIELD = 'django.db.models.AutoField'
 
 # Local time zone for this installation. Choices can be found here:
 # http://en.wikipedia.org/wiki/List_of_tz_zones_by_name
@@ -72,6 +73,7 @@ TEMPLATES = [
         "APP_DIRS": True,
         "OPTIONS": {
             "context_processors": [
+                "django.template.context_processors.request",
                 "django.contrib.auth.context_processors.auth",
                 "django.contrib.messages.context_processors.messages",
             ]

--- a/example_project/settings.py
+++ b/example_project/settings.py
@@ -16,7 +16,7 @@ DATABASES = {
         default="sqlite:///" + project_dir("example_project.db")
     )
 }
-DEFAULT_AUTO_FIELD = 'django.db.models.AutoField'
+DEFAULT_AUTO_FIELD = "django.db.models.AutoField"
 
 # Local time zone for this installation. Choices can be found here:
 # http://en.wikipedia.org/wiki/List_of_tz_zones_by_name

--- a/requirements.txt
+++ b/requirements.txt
@@ -4,14 +4,13 @@
 #
 #    pip-compile requirements.in
 #
-asgiref==3.3.4            # via django
-coverage==5.5             # via -r requirements.in
-dj-database-url==0.5.0    # via -r requirements.in
-django-extensions==3.1.2  # via -r requirements.in
-factory-boy==3.2.0        # via -r requirements.in
-faker==8.0.0              # via factory-boy
-python-dateutil==2.8.1    # via faker
-pytz==2021.1              # via django
-six==1.15.0               # via python-dateutil
-sqlparse==0.4.1           # via django
+coverage==4.5.4
+dj-database-url==0.5.0
+django-extensions==2.2.3
+factory-boy==2.12.0
+faker==2.0.2              # via factory-boy
+mock==3.0.5
+python-dateutil==2.8.0    # via faker
+six==1.12.0               # via django-extensions, faker, mock, python-dateutil
 text-unidecode==1.3       # via faker
+uuid==1.30

--- a/requirements.txt
+++ b/requirements.txt
@@ -4,13 +4,15 @@
 #
 #    pip-compile requirements.in
 #
-coverage==4.5.4
-dj-database-url==0.5.0
-django-extensions==2.2.3
-factory-boy==2.12.0
-faker==2.0.2              # via factory-boy
-mock==3.0.5
-python-dateutil==2.8.0    # via faker
-six==1.12.0               # via django-extensions, faker, mock, python-dateutil
+asgiref==3.3.4            # via django
+coverage==5.5             # via -r requirements.in
+dj-database-url==0.5.0    # via -r requirements.in
+django-extensions==3.1.2  # via -r requirements.in
+django==3.2               # via django-extensions
+factory-boy==3.2.0        # via -r requirements.in
+faker==8.0.0              # via factory-boy
+python-dateutil==2.8.1    # via faker
+pytz==2021.1              # via django
+six==1.15.0               # via python-dateutil
+sqlparse==0.4.1           # via django
 text-unidecode==1.3       # via faker
-uuid==1.30

--- a/requirements.txt
+++ b/requirements.txt
@@ -8,7 +8,6 @@ asgiref==3.3.4            # via django
 coverage==5.5             # via -r requirements.in
 dj-database-url==0.5.0    # via -r requirements.in
 django-extensions==3.1.2  # via -r requirements.in
-django==3.2               # via django-extensions
 factory-boy==3.2.0        # via -r requirements.in
 faker==8.0.0              # via factory-boy
 python-dateutil==2.8.1    # via faker

--- a/tox.ini
+++ b/tox.ini
@@ -32,6 +32,7 @@ deps =
     django22: Django<2.3
     django30: Django<3.1
     django31: Django<3.2
+    django32: Django<3.3
 
 [testenv:coveralls-django21-py37]
 commands =

--- a/tox.ini
+++ b/tox.ini
@@ -11,6 +11,7 @@ envlist =
     django22-{py36,py37},
     django30-{py36,py37,py38},
     django31-{py36,py37,py38},
+    django32-{py36,py37,py38},
     # run one of the tests again but with coverage
     coveralls-django21-py37,
 skipsdist = True


### PR DESCRIPTION
https://docs.djangoproject.com/en/3.2/releases/3.2/

I really need to drop support for old versions now. Lots of deps are starting to step on each other and drop things. Django itself doesn't support Django 3.0 anymore with the release of Django 3.2