### PR TITLE
fix: fix typo in version_variable

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -39,5 +39,5 @@ build-backend = "poetry.core.masonry.api"
 [tool.semantic_release]
 branch = "master"
 version_toml = "pyproject.toml:tool.poetry.version"
-version_variable = "django-object-actions/__init__.py:__version__"
+version_variable = "django_object_actions/__init__.py:__version__"
 build_command = "pip install poetry && poetry build"


### PR DESCRIPTION
Fix "error: [Errno 2] No such file or directory: 'django-object-actions/__init__.py'" error when creating a release