### PR TITLE
chore(ci): upgrade python-semantic-release

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -59,6 +59,6 @@ jobs:
       - name: Set up Python
         uses: actions/setup-python@v3
         with:
-          python-version: "3.10"
+          python-version: "3.11"
       - run: pip install black
       - run: black --check .

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -16,7 +16,7 @@ jobs:
           fetch-depth: 0
       - name: Python Semantic Release
         # https://github.com/relekang/python-semantic-release/releases
-        uses: relekang/python-semantic-release@v7.26.0
+        uses: relekang/python-semantic-release@v7.32.2
         with:
           github_token: ${{ secrets.GITHUB_TOKEN }}
           pypi_token: ${{ secrets.PYPI_TOKEN }}


### PR DESCRIPTION
Hopefully this fixes the broken GitHub Action too https://github.com/crccheck/django-object-actions/actions/runs/3464471740
`error: No module named 'packaging'`

https://github.com/python-semantic-release/python-semantic-release/issues/489

closes #144