### PR TITLE
chore(ci): remove deprecated set-output syntax

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -11,7 +11,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Create matrix
-        uses: fabiocaccamo/create-matrix-action@v1
+        uses: fabiocaccamo/create-matrix-action@v2
         with:
           matrix: |
             python-version {3.7}, django-version {2.0,2.1,2.2,3.0,3.1}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -7,7 +7,7 @@ on:
       - master
 
 jobs:
-  create_matrix:
+  prepare:
     runs-on: ubuntu-latest
     steps:
       - name: Create matrix
@@ -19,19 +19,15 @@ jobs:
             python-version {3.9}, django-version {2.2,3.0,3.1,3.2,4.0,4.1}
             python-version {3.10}, django-version {3.2,4.0,4.1}
             python-version {3.11}, django-version {3.2,4.0,4.1}
-      - name: Set matrix output variable
-        id: set_matrix
-        run: |
-          echo "::set-output name=matrix::$(cat ./matrix.json)"
     outputs:
       matrix: ${{ steps.set_matrix.outputs.matrix }}
 
   test:
-    needs: create_matrix
+    needs: prepare
     strategy:
       fail-fast: false
       matrix:
-        include: ${{ fromJSON(needs.create_matrix.outputs.matrix) }}
+        include: ${{ fromJSON(needs.prepare.outputs.matrix) }}
     name: "Python ${{ matrix.python-version }} + Django ${{ matrix.django-version }}"
     runs-on: ubuntu-latest
     env:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -27,7 +27,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        include: ${{ fromJSON(needs.prepare.outputs.matrix) }}
+        include: ${{ fromJson(needs.prepare.outputs.matrix) }}
     name: "Python ${{ matrix.python-version }} + Django ${{ matrix.django-version }}"
     runs-on: ubuntu-latest
     env:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -34,7 +34,7 @@ jobs:
       POETRY_VIRTUALENVS_CREATE: false
     steps:
       - uses: actions/checkout@v3
-      - uses: actions/setup-python@v3
+      - uses: actions/setup-python@v4
         with:
           python-version: ${{ matrix.python-version }}
       - run: pip install poetry
@@ -53,7 +53,7 @@ jobs:
     steps:
       - uses: actions/checkout@v3
       - name: Set up Python
-        uses: actions/setup-python@v3
+        uses: actions/setup-python@v4
         with:
           python-version: "3.11"
       - run: pip install black

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -20,7 +20,7 @@ jobs:
             python-version {3.10}, django-version {3.2,4.0,4.1}
             python-version {3.11}, django-version {3.2,4.0,4.1}
     outputs:
-      matrix: ${{ steps.set_matrix.outputs.matrix }}
+      matrix: ${{ steps.create_matrix.outputs.matrix }}
 
   test:
     needs: prepare

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -11,6 +11,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Create matrix
+        id: create_matrix
         uses: fabiocaccamo/create-matrix-action@v3
         with:
           matrix: |

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -11,7 +11,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Create matrix
-        uses: fabiocaccamo/create-matrix-action@v2
+        uses: fabiocaccamo/create-matrix-action@v3
         with:
           matrix: |
             python-version {3.7}, django-version {2.0,2.1,2.2,3.0,3.1}


### PR DESCRIPTION
fixes deprecation warnings in CI:
> The `set-output` command is deprecated and will be disabled soon. Please upgrade to using Environment Files. For more information see: https://github.blog/changelog/2022-10-11-github-actions-deprecating-save-state-and-set-output-commands/
