### PR TITLE
fix(ci): update [tool.semantic_release] names

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -39,7 +39,7 @@ dj-database-url = "2.*"
 [tool.semantic_release]
 branch = "master"
 version_toml = ["pyproject.toml:tool.poetry.version"]
-version_variable = "django_object_actions/__init__.py:__version__"
+version_variables = ["django_object_actions/__init__.py:__version__"]
 build_command = "pip install poetry && poetry build"
 
 [tool.coverage.run]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -38,7 +38,7 @@ dj-database-url = "2.*"
 
 [tool.semantic_release]
 branch = "master"
-version_toml = "pyproject.toml:tool.poetry.version"
+version_toml = ["pyproject.toml:tool.poetry.version"]
 version_variable = "django_object_actions/__init__.py:__version__"
 build_command = "pip install poetry && poetry build"
 


### PR DESCRIPTION
I missed some updated config changes
- https://python-semantic-release.readthedocs.io/en/latest/migrating_from_v7.html#version-toml
- https://python-semantic-release.readthedocs.io/en/latest/configuration.html#config-version-variables