### PR TITLE
chore: add Django v5 to CI matrix

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -18,8 +18,9 @@ jobs:
             python-version {3.7}, django-version {2.0,2.1,2.2,3.0,3.1}
             python-version {3.8}, django-version {2.2,3.0,3.1,3.2,4.0,4.1,4.2}
             python-version {3.9}, django-version {2.2,3.0,3.1,3.2,4.0,4.1,4.2}
-            python-version {3.10}, django-version {3.2,4.0,4.1,4.2}
-            python-version {3.11}, django-version {3.2,4.0,4.1,4.2}
+            python-version {3.10}, django-version {3.2,4.0,4.1,4.2,5.0}
+            python-version {3.11}, django-version {3.2,4.0,4.1,4.2,5.0}
+            python-version {3.12}, django-version {4.2, 5.0}
     outputs:
       matrix: ${{ steps.create_matrix.outputs.matrix }}
 


### PR DESCRIPTION
https://docs.djangoproject.com/en/5.0/releases/5.0/