### PR TITLE
wip to select GET or POST for actions

### DIFF
--- a/django_object_actions/templates/django_object_actions/action_trigger.html
+++ b/django_object_actions/templates/django_object_actions/action_trigger.html
@@ -1,0 +1,22 @@
+{% load add_preserved_filters from admin_urls %}
+
+{% if tool.button_type == 'a' %}
+  <a href="{% add_preserved_filters action_url %}"
+    title="{{ tool.standard_attrs.title }}"
+    {% for k, v in tool.custom_attrs.items %}
+      {{ k }}="{{ v }}"
+    {% endfor %}
+    class="{{ tool.standard_attrs.class }}"
+  >{{ tool.label|capfirst }}</a>
+{% elif tool.button_type == 'form' %}
+  <form method="post" action="{% add_preserved_filters action_url %}">
+    {% csrf_token %}
+    <a href="#" onclick="this.parentNode.submit(); return false;"
+      title="{{ tool.standard_attrs.title }}"
+      {% for k, v in tool.custom_attrs.items %}
+        {{ k }}="{{ v }}"
+      {% endfor %}
+      class="{{ tool.standard_attrs.class }}"
+    >{{ tool.label|capfirst }}</a>
+  </form>
+{% endif %}

--- a/django_object_actions/templates/django_object_actions/change_form.html
+++ b/django_object_actions/templates/django_object_actions/change_form.html
@@ -1,17 +1,10 @@
 {% extends "admin/change_form.html" %}
-{% load add_preserved_filters from admin_urls %}
 
 {% block object-tools-items %}
   {% for tool in objectactions %}
     <li class="objectaction-item" data-tool-name="{{ tool.name }}">
       {% url tools_view_name pk=object_id tool=tool.name as action_url %}
-      <a href="{% add_preserved_filters action_url %}" title="{{ tool.standard_attrs.title }}"
-         {% for k, v in tool.custom_attrs.items %}
-           {{ k }}="{{ v }}"
-         {% endfor %}
-         class="{{ tool.standard_attrs.class }}">
-      {{ tool.label|capfirst }}
-      </a>
+      {% include 'django_object_actions/action_trigger.html' %}
     </li>
   {% endfor %}
   {{ block.super }}

--- a/django_object_actions/templates/django_object_actions/change_list.html
+++ b/django_object_actions/templates/django_object_actions/change_list.html
@@ -1,17 +1,10 @@
 {% extends "admin/change_list.html" %}
-{% load add_preserved_filters from admin_urls %}
 
 {% block object-tools-items %}
   {% for tool in objectactions %}
     <li class="objectaction-item" data-tool-name="{{ tool.name }}">
       {% url tools_view_name tool=tool.name as action_url %}
-      <a href="{% add_preserved_filters action_url %}" title="{{ tool.standard_attrs.title }}"
-         {% for k, v in tool.custom_attrs.items %}
-           {{ k }}="{{ v }}"
-         {% endfor %}
-         class="{{ tool.standard_attrs.class }}">
-      {{ tool.label|capfirst }}
-      </a>
+      {% include 'django_object_actions/action_trigger.html' %}
     </li>
   {% endfor %}
   {{ block.super }}


### PR DESCRIPTION
Another try at enforcing POST actions. This change is more gradual than #149 - when library user doesn't change default options the behavior is exactly the same as before the change, that is:

1. Action buttons send GET requests
2. Action handlers accept GET and POST requests

However, user can change this behavior using `methods` and `button_type` kwargs. For example `@action(methods=['POST'], button_type='form')` results in

1. Action button sends POST requests
2. Action handler accepts only POST request

Unfortunately I have this tested only within my project. Also the docs are missing.

And one more thing - I think it is better to use `<input type="submit">` instead of js to submit the form. This js is need to make the buttons look the same in both versions. With proper CSS (that is beyond my ability to write ;) ) js is avoidable and we could be using pretty semantic html submit button. I took the form button template from #149.