### PR TITLE
chore(ci): upgrade python-semantic-release to v9.8.8

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -23,7 +23,8 @@ jobs:
       - name: Python Semantic Release
         id: release
         # https://github.com/python-semantic-release/python-semantic-release/releases
-        uses: python-semantic-release/python-semantic-release@v8.0.8
+        # https://python-semantic-release.readthedocs.io/en/latest/github-action.html
+        uses: python-semantic-release/python-semantic-release@v9.8.8
         with:
           github_token: ${{ secrets.BOT_GITHUB_TOKEN }}
 


### PR DESCRIPTION
There have been a lot of releases since v8.0.8 https://github.com/python-semantic-release/python-semantic-release/blob/master/CHANGELOG.md#v808-2023-08-26

The breaking change was dropping Python 3.7. While this project supports 3.7... that will change the next opportunity