### PR TITLE
fix(ci): Fix release should use python-semantic-release/publish-action

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -2,7 +2,6 @@
 .coverage
 
 .env
-.tox/
 *.db
 *.sqlite
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -19,8 +19,8 @@ jobs:
     steps:
       - uses: actions/checkout@v4
         with:
-          fetch-depth: 0
           ref: ${{ github.ref_name }}
+          fetch-depth: 0
           persist-credentials: false
       - name: Setup | Force release branch to be at workflow sha
         run: |
@@ -40,7 +40,7 @@ jobs:
         if: steps.release.outputs.released == 'true'
 
       - name: Publish | Upload to GitHub Release Assets
-        uses: python-semantic-release/upload-to-gh-release@9.21.0
+        uses: python-semantic-release/publish-action@9.21.0
         if: steps.release.outputs.released == 'true'
         with:
           github_token: ${{ secrets.BOT_GITHUB_TOKEN }}

--- a/django_object_actions/__init__.py
+++ b/django_object_actions/__init__.py
@@ -3,7 +3,6 @@
 __version__ = "4.3.0"
 
 
-# kind of like __all__, make these available for public
 from .utils import (
     BaseDjangoObjectActions,
     DjangoObjectActions,


### PR DESCRIPTION
Unable to resolve action `python-semantic-release/upload-to-gh-release@9.21.0`, unable to find version `9.21.0`

It is now named `python-semantic-release/publish-action`