### PR TITLE
fix: unquote object_id before passing to get_change_actions

### DIFF
--- a/django_object_actions/tests/test_admin.py
+++ b/django_object_actions/tests/test_admin.py
@@ -8,13 +8,70 @@ from django.contrib.admin.utils import quote
 from django.http import HttpResponse
 from django.urls import reverse
 
+from example_project.polls.admin import RelatedDataAdmin
 from example_project.polls.factories import (
     CommentFactory,
     PollFactory,
     RelatedDataFactory,
 )
+from example_project.polls.models import RelatedData
 
 from .tests import LoggedInTestCase
+
+
+class Issue137Tests(LoggedInTestCase):
+    """Test that object_id passed to get_change_actions is unquoted (issue #137)."""
+
+    def test_get_change_actions_can_query_with_object_id(self):
+        """
+        When a model has a CharField primary key with characters that get
+        quoted in URLs (like underscores), get_change_actions should receive
+        the unquoted value so it can query the database, matching Django admin's
+        behavior.
+        """
+        from django.contrib import admin as django_admin
+
+        related_data = RelatedDataFactory(id="user_001_name")
+
+        class QueryingAdmin(RelatedDataAdmin):
+            def get_change_actions(self, request, object_id, form_url):
+                # Before fix, this would fail because object_id is still quoted
+                obj = self.model.objects.get(pk=object_id)
+                if obj.id == related_data.id:
+                    return ["fill_up"]
+                return []
+
+        django_admin.site.unregister(RelatedData)
+        django_admin.site.register(RelatedData, QueryingAdmin)
+        try:
+            admin_change_url = reverse(
+                "admin:polls_relateddata_change", args=(related_data.pk,)
+            )
+            response = self.client.get(admin_change_url)
+            self.assertEqual(response.status_code, 200)
+            # Action should be present since we returned it
+            self.assertIn("fill_up", response.rendered_content)
+        finally:
+            django_admin.site.unregister(RelatedData)
+            django_admin.site.register(RelatedData, RelatedDataAdmin)
+
+    def test_change_view_with_quoted_pk_renders_correct_actions(self):
+        """
+        If get_change_actions uses the object_id to look up the model
+        (e.g. self.model.objects.get(pk=object_id)), it must work with
+        CharField pks that contain URL-quoteable characters.
+        """
+        related_data = RelatedDataFactory(id="item_001_test")
+        quoted_pk = quote(related_data.pk)
+        self.assertNotEqual(quoted_pk, related_data.pk)
+
+        admin_change_url = reverse(
+            "admin:polls_relateddata_change", args=(related_data.pk,)
+        )
+        response = self.client.get(admin_change_url)
+        self.assertEqual(response.status_code, 200)
+        # The action button for 'fill_up' should be rendered
+        self.assertIn("fill_up", response.rendered_content)
 
 
 class CommentTests(LoggedInTestCase):

--- a/django_object_actions/utils.py
+++ b/django_object_actions/utils.py
@@ -90,7 +90,9 @@ class BaseDjangoObjectActions:
             {
                 "objectactions": [
                     self._get_tool_dict(action)
-                    for action in self.get_change_actions(request, object_id, form_url)
+                    for action in self.get_change_actions(
+                        request, unquote(object_id), form_url
+                    )
                 ],
                 "tools_view_name": self.tools_view_name,
             }


### PR DESCRIPTION
## Problem

When Django admin builds URLs for models with **CharField primary keys** (or other pks containing characters like underscores), it quotes the pk value via . 

The current  passes this **still-quoted**  to , which breaks any database lookup inside that method, e.g.:



Django's own  unquotes  before calling . This PR applies the same treatment before passing it to .

## Changes

- :  before passing to 
- Added 2 tests in  to verify CharField pks with quoted characters work correctly

## Verification

All tests pass (39 passed):



Fixes #137

/cc @crccheck